### PR TITLE
fix: thread sourceId/sourceLabel through deterministic parsers

### DIFF
--- a/app/hooks/useDecomposition.ts
+++ b/app/hooks/useDecomposition.ts
@@ -25,7 +25,7 @@ export function useDecomposition() {
     try {
       const { isLatexStructured, parseLatexPropositions } = await import("@/app/lib/utils/latexParser");
       if (isLatexStructured(combinedText)) {
-        const nodes = parseLatexPropositions(combinedText);
+        const nodes = parseLatexPropositions(combinedText, documents);
         if (nodes.length > 0) {
           setState((prev) => ({ ...prev, nodes, extractionStatus: "done" }));
           return;
@@ -39,7 +39,12 @@ export function useDecomposition() {
     if (pdfFile) {
       try {
         const { parsePdfPropositions } = await import("@/app/lib/utils/pdfPropositionParser");
-        const nodes = await parsePdfPropositions(pdfFile);
+        // Find the source document that corresponds to this PDF file
+        const pdfSource = documents.find((d) => d.sourceLabel === pdfFile.name);
+        const nodes = await parsePdfPropositions(
+          pdfFile,
+          pdfSource ? { sourceId: pdfSource.sourceId, sourceLabel: pdfSource.sourceLabel } : undefined,
+        );
         if (nodes && nodes.length > 0) {
           setState((prev) => ({ ...prev, nodes, extractionStatus: "done" }));
           return;

--- a/app/lib/utils/latexParser.ts
+++ b/app/lib/utils/latexParser.ts
@@ -1,4 +1,4 @@
-import type { PropositionKind, PropositionNode } from "@/app/lib/types/decomposition";
+import type { PropositionKind, PropositionNode, SourceDocument } from "@/app/lib/types/decomposition";
 
 /**
  * Map of LaTeX environment names to PropositionKind.
@@ -145,8 +145,20 @@ function extractRefs(text: string): string[] {
  * Extracts theorem-like environments, associates proofs with preceding nodes,
  * resolves \ref/\eqref cross-references into dependsOn edges.
  */
-export function parseLatexPropositions(text: string): PropositionNode[] {
+export function parseLatexPropositions(text: string, documents?: SourceDocument[]): PropositionNode[] {
   const blocks = extractBlocks(text);
+
+  // Build offset ranges for each source document so we can attribute blocks.
+  // The combined text is documents joined by "\n\n", so boundaries are cumulative.
+  const sourceRanges: { sourceId: string; sourceLabel: string; start: number; end: number }[] = [];
+  if (documents && documents.length > 0) {
+    let offset = 0;
+    for (const doc of documents) {
+      const end = offset + doc.text.length;
+      sourceRanges.push({ sourceId: doc.sourceId, sourceLabel: doc.sourceLabel, start: offset, end });
+      offset = end + 2; // account for "\n\n" separator
+    }
+  }
 
   // Per-kind counters for numbering
   const counters: Record<PropositionKind, number> = {
@@ -191,6 +203,9 @@ export function parseLatexPropositions(text: string): PropositionNode[] {
       labelToId[labelKey] = id;
     }
 
+    // Attribute this block to the source document that contains its start offset
+    const source = sourceRanges.find((r) => block.startOffset >= r.start && block.startOffset < r.end);
+
     nodes.push({
       id,
       label,
@@ -198,6 +213,8 @@ export function parseLatexPropositions(text: string): PropositionNode[] {
       statement,
       proofText: "",
       dependsOn: [],
+      sourceId: source?.sourceId ?? "",
+      sourceLabel: source?.sourceLabel ?? "",
       semiformalProof: "",
       leanCode: "",
       verificationStatus: "unverified",

--- a/app/lib/utils/pdfPropositionParser.ts
+++ b/app/lib/utils/pdfPropositionParser.ts
@@ -486,7 +486,10 @@ export async function extractStructuredItems(file: File): Promise<StructuredPage
  * Parse a TeX-compiled PDF into PropositionNodes.
  * Returns null if the PDF doesn't appear to be a structured math document.
  */
-export async function parsePdfPropositions(file: File): Promise<PropositionNode[] | null> {
+export async function parsePdfPropositions(
+  file: File,
+  source?: { sourceId: string; sourceLabel: string },
+): Promise<PropositionNode[] | null> {
   const pages = await extractStructuredItems(file);
 
   // Reconstruct lines across all pages
@@ -531,6 +534,8 @@ export async function parsePdfPropositions(file: File): Promise<PropositionNode[
       statement: seg.body,
       proofText: seg.proofText,
       dependsOn: deps.get(i) ?? [],
+      sourceId: source?.sourceId ?? "",
+      sourceLabel: source?.sourceLabel ?? "",
       semiformalProof: "",
       leanCode: "",
       verificationStatus: "unverified" as const,


### PR DESCRIPTION
## Summary
- LaTeX parser now accepts `documents` array and uses block start offsets to attribute each node to its source document
- PDF parser now accepts optional `source` parameter for single-file attribution
- `useDecomposition` hook updated to pass source info through both fast paths

Fixes the build-breaking TypeScript error where `PropositionNode` objects from the deterministic parsers were missing the required `sourceId` and `sourceLabel` fields (added by the decomposition feature).

## Test plan
- [ ] Upload a single LaTeX file — verify nodes show the correct source label in the proof graph
- [ ] Upload multiple LaTeX files — verify nodes are attributed to the correct source document
- [ ] Upload a TeX-compiled PDF — verify nodes show the PDF filename as source label
- [ ] Verify `npm run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)