### PR TITLE
refactor: extract formalization pipeline from page.tsx

### DIFF
--- a/app/hooks/useFormalizationPipeline.ts
+++ b/app/hooks/useFormalizationPipeline.ts
@@ -1,0 +1,224 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { generateSemiformal, generateLean, verifyLean } from "@/app/lib/formalization/api";
+
+export type LoadingPhase = "idle" | "semiformal" | "lean" | "verifying" | "retrying" | "reverifying" | "iterating";
+export type VerificationStatus = "none" | "verifying" | "valid" | "invalid";
+
+const MAX_LEAN_ATTEMPTS = 3;
+
+/**
+ * Callbacks the pipeline uses to read/write state.
+ * The caller provides these so the same pipeline logic works
+ * for both global state and per-node state.
+ */
+export type PipelineAccessors = {
+  getSemiformal: () => string;
+  setSemiformal: (text: string) => void;
+  getLeanCode: () => string;
+  setLeanCode: (code: string) => void;
+  setVerificationStatus: (status: VerificationStatus) => void;
+  getVerificationErrors: () => string;
+  setVerificationErrors: (errors: string) => void;
+  /** Called before semiformal generation to reset related state */
+  onResetForSemiformal?: () => void;
+  /** Called before lean generation to reset related state */
+  onResetForLean?: () => void;
+  /** Optional: return dependency Lean context for verification */
+  getDependencyContext?: () => string | undefined;
+  /** Optional: mirror updates to session storage */
+  onSessionUpdate?: (updates: Record<string, unknown>) => void;
+};
+
+export type FormalizationPipeline = {
+  loadingPhase: LoadingPhase;
+  handleGenerateSemiformal: (inputText: string) => Promise<void>;
+  handleGenerateLean: () => Promise<void>;
+  handleReVerify: () => Promise<void>;
+  handleLeanIterate: (instruction: string) => Promise<void>;
+  handleRegenerateLean: () => void;
+};
+
+/**
+ * Encapsulates the semiformal → Lean → verify → retry pipeline.
+ *
+ * Accessors are passed via a ref so the pipeline always reads the latest
+ * state without needing to re-create callbacks when accessors change.
+ */
+export function useFormalizationPipeline(accessors: PipelineAccessors): FormalizationPipeline {
+  const [loadingPhase, setLoadingPhase] = useState<LoadingPhase>("idle");
+
+  // Keep a ref to accessors so async callbacks always see the latest version
+  const acc = useRef(accessors);
+  acc.current = accessors;
+
+  const handleGenerateSemiformal = useCallback(async (inputText: string) => {
+    const a = acc.current;
+    a.onResetForSemiformal?.();
+    a.setSemiformal("");
+    a.setLeanCode("");
+    a.setVerificationStatus("none");
+    a.setVerificationErrors("");
+    setLoadingPhase("semiformal");
+
+    try {
+      const proof = await generateSemiformal(inputText);
+      a.setSemiformal(proof);
+      a.onSessionUpdate?.({ semiformalText: proof });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Request failed";
+      a.setSemiformal(`Error: ${msg}`);
+    } finally {
+      setLoadingPhase("idle");
+    }
+  }, []);
+
+  const handleGenerateLean = useCallback(async () => {
+    const a = acc.current;
+    const semiformal = a.getSemiformal();
+    if (!semiformal) return;
+
+    a.onResetForLean?.();
+    a.setLeanCode("");
+    a.setVerificationStatus("none");
+    a.setVerificationErrors("");
+    setLoadingPhase("lean");
+
+    try {
+      const depContext = a.getDependencyContext?.();
+      let currentCode = "";
+      let lastErrors = "";
+
+      for (let attempt = 1; attempt <= MAX_LEAN_ATTEMPTS; attempt++) {
+        if (attempt > 1) setLoadingPhase("retrying");
+        currentCode = await generateLean(
+          semiformal,
+          attempt > 1 ? currentCode : undefined,
+          attempt > 1 ? lastErrors : undefined,
+          undefined,
+          depContext || undefined,
+        );
+        a.setLeanCode(currentCode);
+        a.onSessionUpdate?.({ leanCode: currentCode });
+
+        setLoadingPhase(attempt > 1 ? "reverifying" : "verifying");
+        a.setVerificationStatus("verifying");
+        a.onSessionUpdate?.({ verificationStatus: "verifying" });
+
+        const fullCode = depContext ? `${depContext}\n\n${currentCode}` : currentCode;
+        const { valid, errors } = await verifyLean(fullCode);
+
+        if (valid) {
+          a.setVerificationStatus("valid");
+          a.setVerificationErrors("");
+          a.onSessionUpdate?.({ verificationStatus: "valid", verificationErrors: "" });
+          return;
+        }
+
+        lastErrors = errors || "Verification failed";
+        a.setVerificationErrors(lastErrors);
+        a.onSessionUpdate?.({ verificationErrors: lastErrors });
+        if (attempt === MAX_LEAN_ATTEMPTS) {
+          a.setVerificationStatus("invalid");
+          a.onSessionUpdate?.({ verificationStatus: "invalid" });
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Request failed";
+      const currentLean = a.getLeanCode();
+      if (!currentLean) a.setLeanCode(`-- Error: ${msg}`);
+      else { a.setVerificationStatus("invalid"); a.setVerificationErrors(msg); }
+      a.onSessionUpdate?.({ verificationStatus: "invalid", verificationErrors: msg });
+    } finally {
+      setLoadingPhase("idle");
+    }
+  }, []);
+
+  const handleReVerify = useCallback(async () => {
+    const a = acc.current;
+    const code = a.getLeanCode();
+    if (!code) return;
+
+    setLoadingPhase("verifying");
+    a.setVerificationStatus("verifying");
+    a.setVerificationErrors("");
+    a.onSessionUpdate?.({ verificationStatus: "verifying", verificationErrors: "" });
+
+    try {
+      const depContext = a.getDependencyContext?.();
+      const fullCode = depContext ? `${depContext}\n\n${code}` : code;
+      const { valid, errors } = await verifyLean(fullCode);
+      const vStatus = valid ? "valid" as const : "invalid" as const;
+      const vErrors = valid ? "" : errors || "Verification failed";
+
+      a.setVerificationStatus(vStatus);
+      a.setVerificationErrors(vErrors);
+      a.onSessionUpdate?.({ verificationStatus: vStatus, verificationErrors: vErrors });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Verification request failed";
+      a.setVerificationStatus("invalid");
+      a.setVerificationErrors(msg);
+      a.onSessionUpdate?.({ verificationStatus: "invalid", verificationErrors: msg });
+    } finally {
+      setLoadingPhase("idle");
+    }
+  }, []);
+
+  const handleLeanIterate = useCallback(async (instruction: string) => {
+    const a = acc.current;
+    const semiformal = a.getSemiformal();
+    const currentLean = a.getLeanCode();
+    const currentErrors = a.getVerificationErrors();
+    if (!semiformal) return;
+
+    setLoadingPhase("iterating");
+    a.setVerificationStatus("verifying");
+    a.setVerificationErrors("");
+    a.onSessionUpdate?.({ verificationStatus: "verifying", verificationErrors: "" });
+
+    try {
+      const depContext = a.getDependencyContext?.();
+
+      const newCode = await generateLean(
+        semiformal,
+        currentLean || undefined,
+        currentErrors || undefined,
+        instruction || undefined,
+        depContext || undefined,
+      );
+
+      a.setLeanCode(newCode);
+      a.onSessionUpdate?.({ leanCode: newCode });
+
+      const fullCode = depContext ? `${depContext}\n\n${newCode}` : newCode;
+      const { valid, errors } = await verifyLean(fullCode);
+      const vStatus = valid ? "valid" as const : "invalid" as const;
+      const vErrors = valid ? "" : errors || "Verification failed";
+
+      a.setVerificationStatus(vStatus);
+      a.setVerificationErrors(vErrors);
+      a.onSessionUpdate?.({ verificationStatus: vStatus, verificationErrors: vErrors });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Iteration failed";
+      a.setVerificationStatus("invalid");
+      a.setVerificationErrors(msg);
+      a.onSessionUpdate?.({ verificationStatus: "invalid", verificationErrors: msg });
+    } finally {
+      setLoadingPhase("idle");
+    }
+  }, []);
+
+  const handleRegenerateLean = useCallback(() => {
+    handleLeanIterate("");
+  }, [handleLeanIterate]);
+
+  return {
+    loadingPhase,
+    handleGenerateSemiformal,
+    handleGenerateLean,
+    handleReVerify,
+    handleLeanIterate,
+    handleRegenerateLean,
+  };
+}

--- a/app/lib/formalization/api.ts
+++ b/app/lib/formalization/api.ts
@@ -1,0 +1,48 @@
+/** Shared HTTP helpers for the formalization pipeline. */
+
+/** Fetch a JSON API route, throwing on non-OK responses. */
+export async function fetchApi<T>(
+  url: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error ?? "Request failed");
+  return data as T;
+}
+
+export async function verifyLean(leanCode: string) {
+  const res = await fetch("/api/verification/lean", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ leanCode }),
+  });
+  const data = await res.json();
+  return { valid: Boolean(data.valid), errors: (data.errors as string | undefined) ?? "" };
+}
+
+export async function generateLean(
+  informalProof: string,
+  previousAttempt?: string,
+  errors?: string,
+  instruction?: string,
+  contextLeanCode?: string,
+) {
+  const data = await fetchApi<{ leanCode: string }>(
+    "/api/formalization/lean",
+    { informalProof, previousAttempt, errors, instruction, contextLeanCode },
+  );
+  return data.leanCode;
+}
+
+export async function generateSemiformal(text: string) {
+  const data = await fetchApi<{ proof: string }>(
+    "/api/formalization/semiformal",
+    { text },
+  );
+  return data.proof;
+}

--- a/app/lib/formalization/formalizeNode.ts
+++ b/app/lib/formalization/formalizeNode.ts
@@ -1,37 +1,11 @@
 import type { PropositionNode } from "@/app/lib/types/decomposition";
 import { gatherDependencyContext } from "@/app/lib/utils/leanContext";
+import { generateSemiformal, generateLean, verifyLean } from "@/app/lib/formalization/api";
 
 const MAX_LEAN_ATTEMPTS = 3;
 
 /** Simple cancellation signal checked between async steps. */
 export type CancelSignal = { cancelled: boolean };
-
-async function generateLean(
-  informalProof: string,
-  previousAttempt?: string,
-  errors?: string,
-  instruction?: string,
-  contextLeanCode?: string,
-) {
-  const res = await fetch("/api/formalization/lean", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ informalProof, previousAttempt, errors, instruction, contextLeanCode }),
-  });
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.error ?? "Lean generation failed");
-  return data.leanCode as string;
-}
-
-async function verifyLean(leanCode: string) {
-  const res = await fetch("/api/verification/lean", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ leanCode }),
-  });
-  const data = await res.json();
-  return { valid: Boolean(data.valid), errors: (data.errors as string | undefined) ?? "" };
-}
 
 /**
  * Run the full formalization pipeline for a single node:
@@ -52,22 +26,11 @@ export async function formalizeNode(
     const nodeText = `${node.statement}\n\n${node.proofText}`;
 
     // Step 1: semiformal proof
-    const semiformalRes = await fetch("/api/formalization/semiformal", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text: nodeText }),
-    });
+    const proof = await generateSemiformal(nodeText);
     if (signal?.cancelled) {
       updateNode(node.id, { verificationStatus: "unverified", verificationErrors: "" });
       return "failed";
     }
-
-    const semiformalData = await semiformalRes.json();
-    if (!semiformalRes.ok) {
-      updateNode(node.id, { verificationStatus: "failed", verificationErrors: semiformalData.error ?? "Unknown error" });
-      return "failed";
-    }
-    const proof = semiformalData.proof as string;
     updateNode(node.id, { semiformalProof: proof });
 
     // Step 2: Lean generation with dependency context + retry loop

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,8 @@ import { useDecomposition } from "@/app/hooks/useDecomposition";
 import { useWorkspacePersistence } from "@/app/hooks/useWorkspacePersistence";
 import { useAutoFormalizeQueue } from "@/app/hooks/useAutoFormalizeQueue";
 import { useFormalizationSessions } from "@/app/hooks/useFormalizationSessions";
+import { useFormalizationPipeline } from "@/app/hooks/useFormalizationPipeline";
+import type { VerificationStatus } from "@/app/hooks/useFormalizationPipeline";
 import { ENDPOINT_PRIORS } from "@/app/lib/llm/predict";
 import { gatherDependencyContext } from "@/app/lib/utils/leanContext";
 import {
@@ -25,36 +27,6 @@ import {
   NodeDetailIcon,
   AnalyticsIcon,
 } from "@/app/components/ui/icons/PanelIcons";
-
-type LoadingPhase = "idle" | "semiformal" | "lean" | "verifying" | "retrying" | "reverifying" | "iterating";
-type VerificationStatus = "none" | "verifying" | "valid" | "invalid";
-
-const MAX_LEAN_ATTEMPTS = 3;
-
-async function verifyLean(leanCode: string) {
-  const res = await fetch("/api/verification/lean", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ leanCode }),
-  });
-  const data = await res.json();
-  return { valid: Boolean(data.valid), errors: (data.errors as string | undefined) ?? "" };
-}
-
-/** Fetch a JSON API route. */
-async function fetchApi<T>(
-  url: string,
-  body: Record<string, unknown>,
-): Promise<T> {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.error ?? "Request failed");
-  return data as T;
-}
 
 export default function Home() {
   // --- Panel navigation ---
@@ -72,9 +44,6 @@ export default function Home() {
     verificationErrors, setVerificationErrors,
     restoredDecompState, persistDecompState,
   } = useWorkspacePersistence();
-
-  // --- Ephemeral state (not persisted) ---
-  const [loadingPhase, setLoadingPhase] = useState<LoadingPhase>("idle");
 
   // --- Decomposition state ---
   const { state: decomp, selectedNode, extractPropositions, selectNode, updateNode, resetState: resetDecomp } = useDecomposition();
@@ -112,20 +81,6 @@ export default function Home() {
   } = useFormalizationSessions();
 
 
-  // When in decomposition mode, the semiformal/lean panels show selected node's data
-  const activeSemiformal = isDecompMode ? selectedNode!.semiformalProof : semiformalText;
-  const activeLeanCode = isDecompMode ? selectedNode!.leanCode : leanCode;
-  const activeVerificationStatus: VerificationStatus = isDecompMode
-    ? (selectedNode!.verificationStatus === "verified" ? "valid"
-      : selectedNode!.verificationStatus === "failed" ? "invalid"
-      : selectedNode!.verificationStatus === "in-progress" ? "verifying"
-      : "none")
-    : verificationStatus;
-  const activeVerificationErrors = isDecompMode ? selectedNode!.verificationErrors : verificationErrors;
-
-  // Semiformal exists but Lean hasn't been generated yet — ready for user review
-  const semiformalReadyForLean = activeSemiformal !== "" && activeLeanCode === "" && loadingPhase === "idle";
-
   // --- Combined paper text for single-proof formalization ---
   const combinedPaperText = useMemo(() => {
     return [sourceText, ...extractedFiles.map((f) => `--- ${f.name} ---\n${f.text}`)].filter(Boolean).join("\n\n");
@@ -156,15 +111,64 @@ export default function Home() {
     return docs;
   }, [sourceText, extractedFiles]);
 
-  // --- LLM call helpers that record usage ---
+  // --- Formalization pipelines ---
+  // Helper: mirror updates to the active session
+  const sessionUpdate = useCallback((updates: Record<string, unknown>) => {
+    if (activeSession) updateSession(activeSession.id, updates as Partial<Pick<import("@/app/lib/types/session").FormalizationSession, "semiformalText" | "leanCode" | "verificationStatus" | "verificationErrors">>);
+  }, [activeSession, updateSession]);
 
-  async function generateLean(informalProof: string, previousAttempt?: string, errors?: string, instruction?: string, contextLeanCode?: string) {
-    const data = await fetchApi<{ leanCode: string }>(
-      "/api/formalization/lean",
-      { informalProof, previousAttempt, errors, instruction, contextLeanCode },
-    );
-    return data.leanCode;
-  }
+  // Global pipeline: reads/writes global persisted state
+  const globalPipeline = useFormalizationPipeline({
+    getSemiformal: () => semiformalText,
+    setSemiformal: setSemiformalText,
+    getLeanCode: () => leanCode,
+    setLeanCode: setLeanCode,
+    getVerificationErrors: () => verificationErrors,
+    setVerificationStatus,
+    setVerificationErrors,
+    onResetForSemiformal: () => { setSemiformalDirty(false); },
+    onResetForLean: () => { setSemiformalDirty(false); },
+    onSessionUpdate: sessionUpdate,
+  });
+
+  // Node pipeline: reads/writes selected node state
+  const nodePipeline = useFormalizationPipeline({
+    getSemiformal: () => selectedNode?.semiformalProof ?? "",
+    setSemiformal: (text) => { if (selectedNode) updateNode(selectedNode.id, { semiformalProof: text, verificationStatus: "unverified" }); },
+    getLeanCode: () => selectedNode?.leanCode ?? "",
+    setLeanCode: (code) => { if (selectedNode) updateNode(selectedNode.id, { leanCode: code }); },
+    getVerificationErrors: () => selectedNode?.verificationErrors ?? "",
+    setVerificationStatus: (status) => {
+      if (!selectedNode) return;
+      const nodeStatus = status === "valid" ? "verified" as const
+        : status === "invalid" ? "failed" as const
+        : status === "verifying" ? "in-progress" as const
+        : "unverified" as const;
+      updateNode(selectedNode.id, { verificationStatus: nodeStatus });
+    },
+    setVerificationErrors: (errors) => { if (selectedNode) updateNode(selectedNode.id, { verificationErrors: errors }); },
+    onResetForLean: () => { if (selectedNode) updateNode(selectedNode.id, { verificationStatus: "in-progress", verificationErrors: "" }); },
+    getDependencyContext: () => selectedNode ? gatherDependencyContext(decomp.nodes, selectedNode.id) || undefined : undefined,
+    onSessionUpdate: sessionUpdate,
+  });
+
+  // Active pipeline resolves based on decomposition mode
+  const activePipeline = isDecompMode ? nodePipeline : globalPipeline;
+  const loadingPhase = isDecompMode ? nodePipeline.loadingPhase : globalPipeline.loadingPhase;
+
+  // When in decomposition mode, the semiformal/lean panels show selected node's data
+  const activeSemiformal = isDecompMode ? selectedNode!.semiformalProof : semiformalText;
+  const activeLeanCode = isDecompMode ? selectedNode!.leanCode : leanCode;
+  const activeVerificationStatus: VerificationStatus = isDecompMode
+    ? (selectedNode!.verificationStatus === "verified" ? "valid"
+      : selectedNode!.verificationStatus === "failed" ? "invalid"
+      : selectedNode!.verificationStatus === "in-progress" ? "verifying"
+      : "none")
+    : verificationStatus;
+  const activeVerificationErrors = isDecompMode ? selectedNode!.verificationErrors : verificationErrors;
+
+  // Semiformal exists but Lean hasn't been generated yet — ready for user review
+  const semiformalReadyForLean = activeSemiformal !== "" && activeLeanCode === "" && loadingPhase === "idle";
 
   // --- Handlers ---
 
@@ -187,277 +191,34 @@ export default function Home() {
     if (activeSession) updateSession(activeSession.id, { leanCode: code });
   }, [isDecompMode, selectedNode, updateNode, setLeanCode, activeSession, updateSession]);
 
-  /** Global single-proof: generate semiformal only, then stop for review */
+  /** Global: generate semiformal, create session, navigate to panel */
   const handleGenerateSemiformal = useCallback(async () => {
-    // Deselect any decomposition node so the global semiformalText drives the panel
     selectNode(null);
     createSession({ type: "global" });
-    setLoadingPhase("semiformal");
-    setSemiformalText("");
-    setLeanCode("");
-    setSemiformalDirty(false);
-    setVerificationStatus("none");
-    setVerificationErrors("");
     setActivePanelId("semiformal");
+    await globalPipeline.handleGenerateSemiformal(combinedPaperText);
+  }, [combinedPaperText, selectNode, createSession, globalPipeline]);
 
-    try {
-      const semiformalData = await fetchApi<{ proof: string }>(
-        "/api/formalization/semiformal",
-        { text: combinedPaperText },
-      );
-      setSemiformalText(semiformalData.proof);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Request failed";
-      setSemiformalText(`Error: ${msg}`);
-    } finally {
-      setLoadingPhase("idle");
-    }
-  }, [combinedPaperText, selectNode, createSession, setSemiformalText, setLeanCode, setSemiformalDirty, setVerificationStatus, setVerificationErrors]);
-
-  /** Global single-proof: Lean generation + verification retry loop */
+  /** Global: generate Lean from semiformal, navigate to panel */
   const handleGenerateLean = useCallback(async () => {
-    if (!semiformalText) return;
-
-    setLoadingPhase("lean");
-    setLeanCode("");
-    setSemiformalDirty(false);
-    setVerificationStatus("none");
-    setVerificationErrors("");
     setActivePanelId("lean");
+    await globalPipeline.handleGenerateLean();
+  }, [globalPipeline]);
 
-    try {
-      let currentCode = "";
-      let lastErrors = "";
-
-      for (let attempt = 1; attempt <= MAX_LEAN_ATTEMPTS; attempt++) {
-        if (attempt > 1) setLoadingPhase("retrying");
-        currentCode = await generateLean(
-          semiformalText,
-          attempt > 1 ? currentCode : undefined,
-          attempt > 1 ? lastErrors : undefined,
-        );
-        setLeanCode(currentCode);
-        if (activeSession) updateSession(activeSession.id, { leanCode: currentCode });
-
-        setLoadingPhase(attempt > 1 ? "reverifying" : "verifying");
-        setVerificationStatus("verifying");
-        if (activeSession) updateSession(activeSession.id, { verificationStatus: "verifying" });
-        const { valid, errors } = await verifyLean(currentCode);
-
-        if (valid) {
-          setVerificationStatus("valid");
-          setVerificationErrors("");
-          if (activeSession) updateSession(activeSession.id, { verificationStatus: "valid", verificationErrors: "" });
-          return;
-        }
-
-        lastErrors = errors || "Verification failed";
-        setVerificationErrors(lastErrors);
-        if (activeSession) updateSession(activeSession.id, { verificationErrors: lastErrors });
-        if (attempt === MAX_LEAN_ATTEMPTS) {
-          setVerificationStatus("invalid");
-          if (activeSession) updateSession(activeSession.id, { verificationStatus: "invalid" });
-        }
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Request failed";
-      if (!leanCode) setLeanCode(`-- Error: ${msg}`);
-      else { setVerificationStatus("invalid"); setVerificationErrors(msg); }
-      if (activeSession) updateSession(activeSession.id, { verificationStatus: "invalid", verificationErrors: msg });
-    } finally {
-      setLoadingPhase("idle");
-    }
-  }, [semiformalText, leanCode, setLeanCode, setSemiformalDirty, setVerificationStatus, setVerificationErrors, activeSession, updateSession]);
-
-  /** Per-node: generate semiformal only, then stop for review */
+  /** Per-node: generate semiformal, create session, navigate to panel */
   const handleNodeGenerateSemiformal = useCallback(async () => {
     if (!selectedNode) return;
-
     createSession({ type: "node", nodeId: selectedNode.id, nodeLabel: selectedNode.label });
-    setLoadingPhase("semiformal");
     setActivePanelId("semiformal");
+    const nodeText = `${selectedNode.statement}\n\n${selectedNode.proofText}`;
+    await nodePipeline.handleGenerateSemiformal(nodeText);
+  }, [selectedNode, createSession, nodePipeline]);
 
-    try {
-      const nodeText = `${selectedNode.statement}\n\n${selectedNode.proofText}`;
-      const semiformalData = await fetchApi<{ proof: string }>(
-        "/api/formalization/semiformal",
-        { text: nodeText },
-      );
-      updateNode(selectedNode.id, { semiformalProof: semiformalData.proof, verificationStatus: "unverified" });
-      if (activeSession) updateSession(activeSession.id, { semiformalText: semiformalData.proof });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Request failed";
-      updateNode(selectedNode.id, { verificationStatus: "failed", verificationErrors: msg });
-    } finally {
-      setLoadingPhase("idle");
-    }
-  }, [selectedNode, updateNode, createSession, activeSession, updateSession]);
-
-  /** Per-node: Lean generation + verification retry loop */
+  /** Per-node: generate Lean + verify, navigate to panel */
   const handleNodeGenerateLean = useCallback(async () => {
-    if (!selectedNode || !selectedNode.semiformalProof) return;
-
-    updateNode(selectedNode.id, { verificationStatus: "in-progress", verificationErrors: "" });
-    setLoadingPhase("lean");
     setActivePanelId("lean");
-
-    try {
-      const depContext = gatherDependencyContext(decomp.nodes, selectedNode.id);
-      let currentCode = "";
-      let lastErrors = "";
-
-      for (let attempt = 1; attempt <= MAX_LEAN_ATTEMPTS; attempt++) {
-        if (attempt > 1) setLoadingPhase("retrying");
-        currentCode = await generateLean(
-          selectedNode.semiformalProof,
-          attempt > 1 ? currentCode : undefined,
-          attempt > 1 ? lastErrors : undefined,
-          undefined,
-          depContext || undefined,
-        );
-        updateNode(selectedNode.id, { leanCode: currentCode });
-
-        setLoadingPhase(attempt > 1 ? "reverifying" : "verifying");
-
-        const fullCode = depContext ? `${depContext}\n\n${currentCode}` : currentCode;
-        const { valid, errors } = await verifyLean(fullCode);
-
-        if (valid) {
-          updateNode(selectedNode.id, { verificationStatus: "verified", verificationErrors: "" });
-          return;
-        }
-
-        lastErrors = errors || "Verification failed";
-        updateNode(selectedNode.id, { verificationErrors: lastErrors });
-        if (attempt === MAX_LEAN_ATTEMPTS) {
-          updateNode(selectedNode.id, { verificationStatus: "failed" });
-        }
-      }
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Request failed";
-      updateNode(selectedNode.id, { verificationStatus: "failed", verificationErrors: msg });
-    } finally {
-      setLoadingPhase("idle");
-    }
-  }, [selectedNode, decomp.nodes, updateNode]);
-
-  const handleReVerify = useCallback(async () => {
-    const code = isDecompMode && selectedNode ? selectedNode.leanCode : leanCode;
-    if (!code) return;
-
-    setLoadingPhase("verifying");
-    if (isDecompMode && selectedNode) {
-      updateNode(selectedNode.id, { verificationStatus: "in-progress", verificationErrors: "" });
-    } else {
-      setVerificationStatus("verifying");
-      setVerificationErrors("");
-    }
-    if (activeSession) updateSession(activeSession.id, { verificationStatus: "verifying", verificationErrors: "" });
-
-    try {
-      let fullCode = code;
-      if (isDecompMode && selectedNode) {
-        const depContext = gatherDependencyContext(decomp.nodes, selectedNode.id);
-        if (depContext) fullCode = `${depContext}\n\n${code}`;
-      }
-      const { valid, errors } = await verifyLean(fullCode);
-      const vStatus = valid ? "valid" : "invalid";
-      const vErrors = valid ? "" : errors || "Verification failed";
-
-      if (isDecompMode && selectedNode) {
-        updateNode(selectedNode.id, {
-          verificationStatus: valid ? "verified" : "failed",
-          verificationErrors: vErrors,
-        });
-      } else {
-        setVerificationStatus(vStatus);
-        setVerificationErrors(vErrors);
-      }
-      if (activeSession) updateSession(activeSession.id, { verificationStatus: vStatus, verificationErrors: vErrors });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Verification request failed";
-      if (isDecompMode && selectedNode) {
-        updateNode(selectedNode.id, { verificationStatus: "failed", verificationErrors: msg });
-      } else {
-        setVerificationStatus("invalid");
-        setVerificationErrors(msg);
-      }
-      if (activeSession) updateSession(activeSession.id, { verificationStatus: "invalid", verificationErrors: msg });
-    } finally {
-      setLoadingPhase("idle");
-    }
-  }, [isDecompMode, selectedNode, leanCode, decomp.nodes, updateNode, setVerificationStatus, setVerificationErrors, activeSession, updateSession]);
-
-  const handleLeanIterate = useCallback(async (instruction: string) => {
-    const currentSemiformal = isDecompMode && selectedNode ? selectedNode.semiformalProof : semiformalText;
-    const currentLean = isDecompMode && selectedNode ? selectedNode.leanCode : leanCode;
-    const currentErrors = isDecompMode && selectedNode ? selectedNode.verificationErrors : verificationErrors;
-
-    if (!currentSemiformal) return;
-
-    if (!isDecompMode) setSemiformalDirty(false);
-    setLoadingPhase("iterating");
-
-    if (isDecompMode && selectedNode) {
-      updateNode(selectedNode.id, { verificationStatus: "in-progress", verificationErrors: "" });
-    } else {
-      setVerificationStatus("verifying");
-      setVerificationErrors("");
-    }
-    if (activeSession) updateSession(activeSession.id, { verificationStatus: "verifying", verificationErrors: "" });
-
-    try {
-      const depContext = isDecompMode && selectedNode
-        ? gatherDependencyContext(decomp.nodes, selectedNode.id)
-        : undefined;
-
-      const newCode = await generateLean(
-        currentSemiformal,
-        currentLean || undefined,
-        currentErrors || undefined,
-        instruction || undefined,
-        depContext || undefined,
-      );
-
-      if (isDecompMode && selectedNode) {
-        updateNode(selectedNode.id, { leanCode: newCode });
-      } else {
-        setLeanCode(newCode);
-      }
-      if (activeSession) updateSession(activeSession.id, { leanCode: newCode });
-
-      const fullCode = depContext ? `${depContext}\n\n${newCode}` : newCode;
-      const { valid, errors } = await verifyLean(fullCode);
-      const vStatus = valid ? "valid" : "invalid";
-      const vErrors = valid ? "" : errors || "Verification failed";
-
-      if (isDecompMode && selectedNode) {
-        updateNode(selectedNode.id, {
-          verificationStatus: valid ? "verified" : "failed",
-          verificationErrors: vErrors,
-        });
-      } else {
-        setVerificationStatus(vStatus);
-        setVerificationErrors(vErrors);
-      }
-      if (activeSession) updateSession(activeSession.id, { verificationStatus: vStatus, verificationErrors: vErrors });
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : "Iteration failed";
-      if (isDecompMode && selectedNode) {
-        updateNode(selectedNode.id, { verificationStatus: "failed", verificationErrors: msg });
-      } else {
-        setVerificationStatus("invalid");
-        setVerificationErrors(msg);
-      }
-      if (activeSession) updateSession(activeSession.id, { verificationStatus: "invalid", verificationErrors: msg });
-    } finally {
-      setLoadingPhase("idle");
-    }
-  }, [isDecompMode, selectedNode, semiformalText, leanCode, verificationErrors, decomp.nodes, updateNode, setSemiformalDirty, setVerificationStatus, setVerificationErrors, setLeanCode, activeSession, updateSession]);
-
-  const handleRegenerateLean = useCallback(() => {
-    handleLeanIterate("");
-  }, [handleLeanIterate]);
+    await nodePipeline.handleGenerateLean();
+  }, [nodePipeline]);
 
   /** Load a previous session's data into the current view (supports cross-scope navigation) */
   const handleSelectSession = useCallback((sessionId: string) => {
@@ -645,9 +406,9 @@ export default function Home() {
         verificationErrors={activeVerificationErrors}
         semiformalDirty={!isDecompMode && semiformalDirty}
         semiformalReady={semiformalReadyForLean}
-        onRegenerateLean={handleRegenerateLean}
-        onReVerify={handleReVerify}
-        onLeanIterate={handleLeanIterate}
+        onRegenerateLean={activePipeline.handleRegenerateLean}
+        onReVerify={activePipeline.handleReVerify}
+        onLeanIterate={activePipeline.handleLeanIterate}
         sessionBanner={sessionBannerElement}
       />
     ),
@@ -689,7 +450,7 @@ export default function Home() {
     queueProgress, startQueue, pauseQueue, resumeQueue, cancelQueue,
     setSourceText, setExtractedFiles, setContextText,
     handleGenerateSemiformal, handleGenerateLean, handleSemiformalTextChange, handleLeanCodeChange,
-    handleRegenerateLean, handleReVerify, handleLeanIterate,
+    activePipeline,
     handleSelectNode, handleDecompose, handleNodeGenerateSemiformal, handleNodeGenerateLean,
     activeSession, allSessions, handleSelectSession,
   ]);

--- a/docs/thoughts/page-tsx-refactor.md
+++ b/docs/thoughts/page-tsx-refactor.md
@@ -1,0 +1,179 @@
+# page.tsx Refactor Design
+
+Preparatory refactor for [002-multi-artifact-ui-layout](../decisions/002-multi-artifact-ui-layout.md). Goal: reduce page.tsx from a 709-line monolith to a thin composition shell so adding 4 new artifact types doesn't make it unmaintainable.
+
+## Problem Analysis
+
+page.tsx currently mixes five concerns:
+
+1. **Formalization orchestration** (~150 lines) — `handleGenerateSemiformal`, `handleGenerateLean`, `handleReVerify`, `handleLeanIterate`, `handleRegenerateLean` plus the retry loop logic, `verifyLean`, `fetchApi`, `generateLean` helpers
+2. **Decomposition ↔ formalization bridge** (~80 lines) — `handleNodeGenerateSemiformal`, `handleNodeGenerateLean`, all the `isDecompMode` branching for active state resolution (`activeSemiformal`, `activeLeanCode`, `activeVerificationStatus`, etc.)
+3. **Session wiring** (~40 lines) — `handleSelectSession`, session creation/update calls scattered through every handler
+4. **Panel definitions** (~60 lines) — the `panels` array with icons, labels, status summaries
+5. **Panel content map** (~80 lines) — the `panelContent` record wiring props to each panel component
+
+The `isDecompMode` branching is the worst smell — nearly every handler has an `if (isDecompMode && selectedNode)` / `else` fork. This will multiply when each fork also needs to handle 5 artifact types instead of 1.
+
+## Proposed Structure
+
+### New Hook: `useFormalizationPipeline`
+
+**File:** `app/hooks/useFormalizationPipeline.ts`
+
+Extracts all formalization orchestration — the generate/verify/retry/iterate loop — into a single hook that works for both global and per-node contexts. This is the highest-value extraction because:
+- It's the largest block of logic (~230 lines including both global and node variants)
+- The global and per-node variants are near-duplicates with minor differences (where state is read/written, whether dependency context is gathered)
+- When new artifact types arrive, each will have its own pipeline; having the deductive pipeline in a hook establishes the pattern
+
+```typescript
+// Inputs: where to read/write state, optional dependency context
+type PipelineConfig = {
+  getSemiformal: () => string;
+  setSemiformal: (text: string) => void;
+  getLeanCode: () => string;
+  setLeanCode: (code: string) => void;
+  setVerificationStatus: (status: VerificationStatus) => void;
+  setVerificationErrors: (errors: string) => void;
+  getDependencyContext?: () => string | undefined;
+  onSessionUpdate?: (updates: Partial<SessionUpdates>) => void;
+};
+
+// Returns: handler functions + loading state
+type PipelineReturn = {
+  loadingPhase: LoadingPhase;
+  generateSemiformal: (inputText: string) => Promise<void>;
+  generateLean: () => Promise<void>;
+  reVerify: () => Promise<void>;
+  leanIterate: (instruction: string) => Promise<void>;
+  regenerateLean: () => Promise<void>;
+};
+```
+
+The key insight: instead of `isDecompMode` branching inside every handler, the *caller* provides the right read/write accessors. page.tsx creates two pipeline instances — one for global, one that targets the selected node — and passes the appropriate one to panels.
+
+### New Hook: `useActiveArtifactState`
+
+**File:** `app/hooks/useActiveArtifactState.ts`
+
+Extracts the `isDecompMode` resolution logic — the ~20 lines that compute `activeSemiformal`, `activeLeanCode`, `activeVerificationStatus`, `activeVerificationErrors`, `semiformalReadyForLean` from either the selected node or global state.
+
+```typescript
+function useActiveArtifactState(
+  globalState: { semiformalText: string; leanCode: string; verificationStatus: VerificationStatus; verificationErrors: string },
+  selectedNode: PropositionNode | null,
+  loadingPhase: LoadingPhase,
+): {
+  isDecompMode: boolean;
+  activeSemiformal: string;
+  activeLeanCode: string;
+  activeVerificationStatus: VerificationStatus;
+  activeVerificationErrors: string;
+  semiformalReadyForLean: boolean;
+}
+```
+
+Small but eliminates the scattered derivation logic from page.tsx and gives a single place to extend when new artifact types need their own active-state resolution.
+
+### Extract: `usePanelDefinitions`
+
+**File:** `app/hooks/usePanelDefinitions.ts`
+
+The `panels` array definition (lines 525-582) is pure derived state from a handful of inputs. Extract it to declutter page.tsx and make it easy to add new panel entries for the 4 new artifact types.
+
+```typescript
+function usePanelDefinitions(opts: {
+  sourceText: string;
+  extractedFiles: { name: string }[];
+  contextText: string;
+  activeSemiformal: string;
+  activeLeanCode: string;
+  loadingPhase: LoadingPhase;
+  activeVerificationStatus: VerificationStatus;
+  semiformalReadyForLean: boolean;
+  decomp: { nodes: PropositionNode[] };
+  selectedNode: PropositionNode | null;
+}): PanelDef[]
+```
+
+### Do NOT Extract: Panel Content Map
+
+The `panelContent` record (lines 607-695) wires specific props to specific panel components. This is inherently a composition concern — it's the thing page.tsx *should* be doing. Extracting it would just move the prop-threading somewhere else without reducing complexity. Keep it in page.tsx but benefit from the smaller handler functions (pipeline hooks replace the inline callbacks).
+
+### Do NOT Extract: `fetchApi` / `verifyLean`
+
+These are thin HTTP helpers used only by the pipeline. Move them into `useFormalizationPipeline` or into a small `app/lib/formalization/api.ts` utility. They don't need their own hook.
+
+## Migration Plan
+
+Three PRs, each independently mergeable and testable:
+
+### PR 1: Extract `useFormalizationPipeline`
+
+1. Create `app/lib/formalization/api.ts` — move `fetchApi`, `verifyLean`, `generateLean` (the fetch wrappers from page.tsx lines 34-167)
+2. Create `app/hooks/useFormalizationPipeline.ts` — the hook with the config-based approach above
+3. In page.tsx: create two pipeline instances (global + node), replace all 6 handler functions with pipeline methods
+4. Verify: `npm run build` + manual test of generate semiformal → generate lean → verify → iterate flow in both global and decomposition modes
+
+Expected page.tsx reduction: ~200 lines removed, ~20 lines added for pipeline instantiation.
+
+### PR 2: Extract `useActiveArtifactState` + `usePanelDefinitions`
+
+1. Create `app/hooks/useActiveArtifactState.ts`
+2. Create `app/hooks/usePanelDefinitions.ts`
+3. Update page.tsx to use both
+4. Verify: build + lint
+
+Expected page.tsx reduction: ~80 lines removed, ~10 lines added for hook calls.
+
+### PR 3: Simplify session wiring
+
+1. Move `handleSelectSession` logic into `useFormalizationSessions` (it's session-management logic that currently lives in page.tsx because it needs to update decomposition/global state — solve by passing update callbacks to the hook or by having the hook return a richer `selectSession` that accepts a state-update callback)
+2. Reduce the scattered `if (activeSession) updateSession(...)` calls by integrating session tracking into the pipeline hook's `onSessionUpdate` callback
+
+Expected page.tsx reduction: ~40 lines of scattered session update calls consolidated.
+
+## Post-Refactor page.tsx Shape
+
+```typescript
+export default function Home() {
+  const [activePanelId, setActivePanelId] = useState<PanelId>("source");
+
+  // Persisted state
+  const { sourceText, setSourceText, ... } = useWorkspacePersistence();
+
+  // Decomposition
+  const { state: decomp, selectedNode, ... } = useDecomposition();
+
+  // Active artifact resolution
+  const { isDecompMode, activeSemiformal, ... } = useActiveArtifactState(globalState, selectedNode, loadingPhase);
+
+  // Formalization pipelines (global + per-node)
+  const globalPipeline = useFormalizationPipeline({ /* global accessors */ });
+  const nodePipeline = useFormalizationPipeline({ /* node accessors */ });
+  const activePipeline = isDecompMode ? nodePipeline : globalPipeline;
+
+  // Sessions
+  const { activeSession, ... } = useFormalizationSessions();
+
+  // Auto-formalize queue
+  const { progress: queueProgress, ... } = useAutoFormalizeQueue(decomp.nodes, updateNode);
+
+  // Panel definitions
+  const panels = usePanelDefinitions({ ... });
+
+  // Panel content (the composition glue — this IS what page.tsx is for)
+  const panelContent = useMemo(() => ({ ... }), [...]);
+
+  return <PanelShell ... />;
+}
+```
+
+Target: ~250 lines, down from 709. The remaining lines are panel content wiring (which will grow as new artifact panels are added, but each new panel is ~15 lines of JSX, not ~80 lines of handler logic).
+
+## Risks
+
+- **Two pipeline instances sharing `loadingPhase`**: Both pipelines write to a single loading indicator. Options: (a) each pipeline owns its own phase and page.tsx derives a combined phase, or (b) pass a shared setter. Option (a) is cleaner — the UI can show per-pipeline loading independently, which matters when 002 enables parallel generation of multiple artifact types.
+
+- **Stale closures in pipeline config**: The config callbacks (`getSemiformal`, etc.) capture state at hook creation time. Use refs or pass current values through function parameters rather than closing over state values.
+
+- **Session update integration**: The pipeline's `onSessionUpdate` callback needs the active session ID, which changes when `createSession` is called at the start of a pipeline run. The pipeline hook should accept a session ID ref or a `getSessionId` callback rather than a static ID.


### PR DESCRIPTION
## Summary

- Extract the generate→verify→retry→iterate formalization loop from `page.tsx` into `useFormalizationPipeline`, a config-driven hook that eliminates duplicated global/node handler pairs
- Extract shared HTTP helpers (`fetchApi`, `verifyLean`, `generateLean`, `generateSemiformal`) into `app/lib/formalization/api.ts`, shared by both the pipeline hook and `formalizeNode.ts`
- Reduce `page.tsx` from 709 → 470 lines by replacing 6 handler functions with two pipeline instances (global + node)

Preparatory refactor for [002-multi-artifact-ui-layout](docs/decisions/002-multi-artifact-ui-layout.md). See [design notes](docs/thoughts/page-tsx-refactor.md) for the full plan (this is PR 1 of 3).

## Key design decisions

- **Accessor-based config**: The pipeline hook takes callbacks (`getSemiformal`, `setSemiformal`, etc.) so the same logic works for both global state and per-node state without `isDecompMode` branching
- **Ref-based accessor storage**: Uses `acc.current = accessors` so async callbacks always read the latest state, avoiding stale closures when node selection changes mid-pipeline
- **Shared API module**: `formalizeNode.ts` (used by the auto-formalize queue) now imports from the same `api.ts` instead of duplicating fetch helpers

## Test plan

- [ ] Manual: generate semiformal from source text (global mode) — verify panel navigation and content
- [ ] Manual: generate Lean from semiformal (global mode) — verify retry loop and verification status
- [ ] Manual: decompose → select node → generate semiformal → generate Lean (node mode)
- [ ] Manual: iterate on Lean code with instruction (both modes)
- [ ] Manual: re-verify edited Lean code (both modes)
- [ ] Manual: auto-formalize queue still works (uses updated `formalizeNode.ts`)
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)