### PR TITLE
refactor: simplify session wiring in page.tsx

### DIFF
--- a/app/hooks/useFormalizationSessions.ts
+++ b/app/hooks/useFormalizationSessions.ts
@@ -1,7 +1,11 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import type { FormalizationSession, SessionScope, SessionsState } from "@/app/lib/types/session";
+
+export type SessionRestoreHandler = (session: FormalizationSession) => void;
+
+type SessionUpdatableFields = Partial<Pick<FormalizationSession, "semiformalText" | "leanCode" | "verificationStatus" | "verificationErrors">>;
 
 const STORAGE_KEY = "metaformalism-sessions";
 
@@ -22,9 +26,13 @@ function scopeMatches(a: SessionScope, b: SessionScope): boolean {
   return a.type === "node" && b.type === "node" && a.nodeId === b.nodeId;
 }
 
-export function useFormalizationSessions() {
+export function useFormalizationSessions(onRestore?: SessionRestoreHandler) {
   const [state, setState] = useState<SessionsState>(loadFromStorage);
   const mounted = useRef(false);
+
+  // Ref so selectAndRestore always sees the latest callback without recreating
+  const onRestoreRef = useRef(onRestore);
+  useEffect(() => { onRestoreRef.current = onRestore; }, [onRestore]);
 
   // Persist to localStorage on every change after initial mount
   useEffect(() => {
@@ -65,7 +73,7 @@ export function useFormalizationSessions() {
     return newSession;
   }, []);
 
-  const updateSession = useCallback((id: string, updates: Partial<Pick<FormalizationSession, "semiformalText" | "leanCode" | "verificationStatus" | "verificationErrors">>) => {
+  const updateSession = useCallback((id: string, updates: SessionUpdatableFields) => {
     setState((prev) => ({
       ...prev,
       sessions: prev.sessions.map((s) =>
@@ -78,6 +86,36 @@ export function useFormalizationSessions() {
 
   const selectSession = useCallback((id: string) => {
     setState((prev) => ({ ...prev, activeSessionId: id }));
+  }, []);
+
+  /**
+   * Select a session and restore its state into the workspace.
+   * Calls the onRestore callback (provided at hook init) with the session data
+   * so the caller can apply it to global or per-node state.
+   */
+  const selectAndRestore = useCallback((sessionId: string) => {
+    const session = state.sessions.find((s) => s.id === sessionId);
+    if (!session) return;
+    setState((prev) => ({ ...prev, activeSessionId: sessionId }));
+    onRestoreRef.current?.(session);
+  }, [state.sessions]);
+
+  /**
+   * Mirror an update to the active session (if one exists).
+   * Consolidates the scattered `if (activeSession) updateSession(...)` pattern.
+   */
+  const syncToActiveSession = useCallback((updates: SessionUpdatableFields) => {
+    setState((prev) => {
+      if (!prev.activeSessionId) return prev;
+      return {
+        ...prev,
+        sessions: prev.sessions.map((s) =>
+          s.id === prev.activeSessionId
+            ? { ...s, ...updates, updatedAt: new Date().toISOString() }
+            : s
+        ),
+      };
+    });
   }, []);
 
   const clearActiveSession = useCallback(() => {
@@ -98,12 +136,21 @@ export function useFormalizationSessions() {
     return scopeMatches(activeSession.scope, scope) ? activeSession : null;
   }, [activeSession]);
 
+  // All sessions sorted by run number (descending), for use in session banners
+  const allSessionsSorted = useMemo(() =>
+    [...state.sessions].sort((a, b) => b.runNumber - a.runNumber || b.updatedAt.localeCompare(a.updatedAt)),
+    [state.sessions],
+  );
+
   return {
     sessions: state.sessions,
+    allSessionsSorted,
     activeSession,
     createSession,
     updateSession,
     selectSession,
+    selectAndRestore,
+    syncToActiveSession,
     clearActiveSession,
     sessionsForScope,
     activeSessionForScope,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import type { PanelId } from "@/app/lib/types/panels";
 import type { SourceDocument } from "@/app/lib/types/decomposition";
+import type { FormalizationSession } from "@/app/lib/types/session";
 import PanelShell from "@/app/components/layout/PanelShell";
 import InputPanel from "@/app/components/panels/InputPanel";
 import SemiformalPanel from "@/app/components/panels/SemiformalPanel";
@@ -65,13 +66,39 @@ export default function Home() {
   }, [decomp.nodes, decomp.selectedNodeId, decomp.paperText, persistDecompState]);
 
   // --- Session state ---
+  // Restore callback: applies a session's data to global or per-node state
+  const handleRestoreSession = useCallback((session: FormalizationSession) => {
+    if (session.scope.type === "node") {
+      selectNode(session.scope.nodeId);
+      const nodeStatus = session.verificationStatus === "valid" ? "verified" as const
+        : session.verificationStatus === "invalid" ? "failed" as const
+        : session.verificationStatus === "verifying" ? "in-progress" as const
+        : "unverified" as const;
+      updateNode(session.scope.nodeId, {
+        semiformalProof: session.semiformalText,
+        leanCode: session.leanCode,
+        verificationStatus: nodeStatus,
+        verificationErrors: session.verificationErrors,
+      });
+    } else {
+      selectNode(null);
+      setSemiformalText(session.semiformalText);
+      setLeanCode(session.leanCode);
+      setVerificationStatus(session.verificationStatus);
+      setVerificationErrors(session.verificationErrors);
+      setSemiformalDirty(false);
+    }
+  }, [selectNode, updateNode, setSemiformalText, setLeanCode, setVerificationStatus, setVerificationErrors, setSemiformalDirty]);
+
   const {
     activeSession,
+    allSessionsSorted,
     createSession,
-    updateSession,
+    syncToActiveSession,
     selectSession,
+    selectAndRestore,
     sessionsForScope,
-  } = useFormalizationSessions();
+  } = useFormalizationSessions(handleRestoreSession);
 
 
   // --- Combined paper text for single-proof formalization ---
@@ -105,11 +132,6 @@ export default function Home() {
   }, [sourceText, extractedFiles]);
 
   // --- Formalization pipelines ---
-  // Helper: mirror updates to the active session
-  const sessionUpdate = useCallback((updates: Record<string, unknown>) => {
-    if (activeSession) updateSession(activeSession.id, updates as Partial<Pick<import("@/app/lib/types/session").FormalizationSession, "semiformalText" | "leanCode" | "verificationStatus" | "verificationErrors">>);
-  }, [activeSession, updateSession]);
-
   // Global pipeline: reads/writes global persisted state
   const globalPipeline = useFormalizationPipeline({
     getSemiformal: () => semiformalText,
@@ -121,7 +143,7 @@ export default function Home() {
     setVerificationErrors,
     onResetForSemiformal: () => { setSemiformalDirty(false); },
     onResetForLean: () => { setSemiformalDirty(false); },
-    onSessionUpdate: sessionUpdate,
+    onSessionUpdate: syncToActiveSession,
   });
 
   // Node pipeline: reads/writes selected node state
@@ -142,7 +164,7 @@ export default function Home() {
     setVerificationErrors: (errors) => { if (selectedNode) updateNode(selectedNode.id, { verificationErrors: errors }); },
     onResetForLean: () => { if (selectedNode) updateNode(selectedNode.id, { verificationStatus: "in-progress", verificationErrors: "" }); },
     getDependencyContext: () => selectedNode ? gatherDependencyContext(decomp.nodes, selectedNode.id) || undefined : undefined,
-    onSessionUpdate: sessionUpdate,
+    onSessionUpdate: syncToActiveSession,
   });
 
   // Active pipeline resolves based on decomposition mode
@@ -170,8 +192,8 @@ export default function Home() {
       setSemiformalText(text);
       setSemiformalDirty((prev) => prev || leanCode !== "");
     }
-    if (activeSession) updateSession(activeSession.id, { semiformalText: text });
-  }, [isDecompMode, selectedNode, updateNode, leanCode, setSemiformalText, setSemiformalDirty, activeSession, updateSession]);
+    syncToActiveSession({ semiformalText: text });
+  }, [isDecompMode, selectedNode, updateNode, leanCode, setSemiformalText, setSemiformalDirty, syncToActiveSession]);
 
   const handleLeanCodeChange = useCallback((code: string) => {
     if (isDecompMode && selectedNode) {
@@ -179,8 +201,8 @@ export default function Home() {
     } else {
       setLeanCode(code);
     }
-    if (activeSession) updateSession(activeSession.id, { leanCode: code });
-  }, [isDecompMode, selectedNode, updateNode, setLeanCode, activeSession, updateSession]);
+    syncToActiveSession({ leanCode: code });
+  }, [isDecompMode, selectedNode, updateNode, setLeanCode, syncToActiveSession]);
 
   /** Global: generate semiformal, create session, navigate to panel */
   const handleGenerateSemiformal = useCallback(async () => {
@@ -210,39 +232,6 @@ export default function Home() {
     setActivePanelId("lean");
     await nodePipeline.handleGenerateLean();
   }, [nodePipeline]);
-
-  /** Load a previous session's data into the current view (supports cross-scope navigation) */
-  const handleSelectSession = useCallback((sessionId: string) => {
-    selectSession(sessionId);
-    const allSessions = sessionsForScope({ type: "global" }).concat(
-      decomp.nodes.flatMap((n) => sessionsForScope({ type: "node", nodeId: n.id, nodeLabel: n.label }))
-    );
-    const target = allSessions.find((s) => s.id === sessionId);
-    if (!target) return;
-
-    if (target.scope.type === "node") {
-      // Navigate into the target node
-      selectNode(target.scope.nodeId);
-      const nodeStatus = target.verificationStatus === "valid" ? "verified"
-        : target.verificationStatus === "invalid" ? "failed"
-        : target.verificationStatus === "verifying" ? "in-progress"
-        : "unverified";
-      updateNode(target.scope.nodeId, {
-        semiformalProof: target.semiformalText,
-        leanCode: target.leanCode,
-        verificationStatus: nodeStatus,
-        verificationErrors: target.verificationErrors,
-      });
-    } else {
-      // Global session — exit decomposition mode
-      selectNode(null);
-      setSemiformalText(target.semiformalText);
-      setLeanCode(target.leanCode);
-      setVerificationStatus(target.verificationStatus);
-      setVerificationErrors(target.verificationErrors);
-      setSemiformalDirty(false);
-    }
-  }, [selectSession, sessionsForScope, decomp.nodes, selectNode, updateNode, setSemiformalText, setLeanCode, setVerificationStatus, setVerificationErrors, setSemiformalDirty]);
 
   // Graph panel handlers
   const handleDecompose = useCallback(() => {
@@ -294,21 +283,12 @@ export default function Home() {
   }, [semiformalText, leanCode, decomp.nodes]);
 
   // --- Panel content map ---
-  // Collect all sessions for the banner dropdown (global + all node scopes)
-  const allSessions = useMemo(() => {
-    const global = sessionsForScope({ type: "global" });
-    const nodeSessions = decomp.nodes.flatMap((n) =>
-      sessionsForScope({ type: "node", nodeId: n.id, nodeLabel: n.label })
-    );
-    return [...global, ...nodeSessions].sort((a, b) => b.runNumber - a.runNumber || b.updatedAt.localeCompare(a.updatedAt));
-  }, [sessionsForScope, decomp.nodes]);
-
   const panelContent: Partial<Record<PanelId, React.ReactNode>> = useMemo(() => {
   const sessionBannerElement = activeSession ? (
     <SessionBanner
       currentSession={activeSession}
-      sessions={allSessions}
-      onSelectSession={handleSelectSession}
+      sessions={allSessionsSorted}
+      onSelectSession={selectAndRestore}
     />
   ) : null;
 
@@ -390,7 +370,7 @@ export default function Home() {
     handleGenerateSemiformal, handleGenerateLean, handleSemiformalTextChange, handleLeanCodeChange,
     activePipeline,
     handleSelectNode, handleDecompose, handleNodeGenerateSemiformal, handleNodeGenerateLean,
-    activeSession, allSessions, handleSelectSession,
+    activeSession, allSessionsSorted, selectAndRestore,
   ]);
 
   return (


### PR DESCRIPTION
## Summary

- **Add `selectAndRestore()` to `useFormalizationSessions`** — combines session selection + state restoration via an `onRestore` callback, replacing the 30-line `handleSelectSession` in page.tsx
- **Add `syncToActiveSession()`** — consolidates scattered `if (activeSession) updateSession(activeSession.id, ...)` calls into a single method that checks internally
- **Add `allSessionsSorted`** — pre-sorted session list from the hook, eliminating a `useMemo` computation in page.tsx

page.tsx: 408 → 388 lines (-20 net). `updateSession` no longer referenced in page.tsx.

Part 3 of 3 in the page.tsx refactor series ([design doc](docs/thoughts/page-tsx-refactor.md)). Depends on #PR2 (`refactor/extract-active-state-and-panel-defs`).

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Manual: generate semiformal → generate lean → verify → iterate flow works in global mode
- [ ] Manual: same flow works in decomposition mode (select a node, formalize)
- [ ] Manual: session banner dropdown shows all sessions, selecting a previous session restores its state
- [ ] Manual: editing semiformal/lean text in either mode updates the active session

🤖 Generated with [Claude Code](https://claude.com/claude-code)