### PR TITLE
Fix duplicate file display and input panel scrolling

### DIFF
--- a/app/components/features/source-input/FileUpload.tsx
+++ b/app/components/features/source-input/FileUpload.tsx
@@ -103,6 +103,11 @@ export default function FileUpload({ onFilesChanged }: FileUploadProps) {
               <span className="flex items-center gap-2 truncate">
                 <StatusIndicator status={tf.status} />
                 <span className="truncate">{tf.file.name}</span>
+                {tf.status === "ready" && (
+                  <span className="ml-auto shrink-0 text-[10px] text-[#9A9590]">
+                    {tf.text.length.toLocaleString()} chars
+                  </span>
+                )}
                 {tf.status === "error" && tf.error && (
                   <span className="text-xs text-red-600" title={tf.error}>
                     — {tf.error}

--- a/app/components/panels/InputPanel.test.tsx
+++ b/app/components/panels/InputPanel.test.tsx
@@ -17,7 +17,6 @@ describe('InputPanel', () => {
   const defaultProps = {
     sourceText: 'source',
     onSourceTextChange: vi.fn(),
-    extractedFiles: [] as { name: string; text: string }[],
     onFilesChanged: vi.fn(),
     contextText: 'context',
     onContextTextChange: vi.fn(),

--- a/app/components/panels/InputPanel.tsx
+++ b/app/components/panels/InputPanel.tsx
@@ -7,7 +7,6 @@ import FormalizationControls from "@/app/components/features/formalization-contr
 type InputPanelProps = {
   sourceText: string;
   onSourceTextChange: (value: string) => void;
-  extractedFiles: { name: string; text: string }[];
   onFilesChanged: (files: { name: string; text: string }[]) => void;
   contextText: string;
   onContextTextChange: (value: string) => void;
@@ -25,7 +24,6 @@ type InputPanelProps = {
 export default function InputPanel({
   sourceText,
   onSourceTextChange,
-  extractedFiles,
   onFilesChanged,
   contextText,
   onContextTextChange,
@@ -40,7 +38,7 @@ export default function InputPanel({
   return (
     <div className="relative flex h-full flex-col overflow-hidden bg-[var(--ivory-cream)]">
       {/* Top Section: Source Inputs */}
-      <div className="flex min-h-0 flex-col overflow-hidden border-b border-[#DDD9D5]">
+      <div className="flex max-h-[50%] min-h-0 flex-col overflow-hidden border-b border-[#DDD9D5]">
         <div className="border-b border-[#DDD9D5] bg-[#F5F1ED] px-4 py-2">
           <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--ink-black)]">
             Source Inputs
@@ -49,28 +47,6 @@ export default function InputPanel({
         <div className="flex min-h-0 flex-col gap-3 overflow-auto p-4">
           <TextInput value={sourceText} onChange={onSourceTextChange} />
           <FileUpload onFilesChanged={onFilesChanged} />
-
-          {extractedFiles.length > 0 && (
-            <section>
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
-                Uploaded Documents
-              </h3>
-              <ul className="space-y-1">
-                {extractedFiles.map((f) => (
-                  <li
-                    key={f.name}
-                    className="flex items-center gap-2 rounded-md border border-[#E8E4E0] bg-white px-3 py-2 text-sm text-[var(--ink-black)] shadow-sm"
-                  >
-                    <span className="text-green-600" aria-hidden>&#10003;</span>
-                    <span className="truncate">{f.name}</span>
-                    <span className="ml-auto shrink-0 text-[10px] text-[#9A9590]">
-                      {f.text.length.toLocaleString()} chars
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
 
           {/* Decompose action */}
           {onDecompose && (

--- a/app/components/panels/SourcePanel.tsx
+++ b/app/components/panels/SourcePanel.tsx
@@ -4,11 +4,10 @@ import FileUpload from "@/app/components/features/source-input/FileUpload";
 type SourcePanelProps = {
   sourceText: string;
   onSourceTextChange: (value: string) => void;
-  extractedFiles: { name: string; text: string; file?: File }[];
   onFilesChanged: (files: { name: string; text: string; file?: File }[]) => void;
 };
 
-export default function SourcePanel({ sourceText, onSourceTextChange, extractedFiles, onFilesChanged }: SourcePanelProps) {
+export default function SourcePanel({ sourceText, onSourceTextChange, onFilesChanged }: SourcePanelProps) {
   return (
     <div className="flex h-full flex-col overflow-hidden bg-[var(--ivory-cream)]">
       <div className="border-b border-[#DDD9D5] bg-[#F5F1ED] px-6 py-3">
@@ -19,28 +18,6 @@ export default function SourcePanel({ sourceText, onSourceTextChange, extractedF
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-auto p-6">
         <TextInput value={sourceText} onChange={onSourceTextChange} />
         <FileUpload onFilesChanged={onFilesChanged} />
-
-        {extractedFiles.length > 0 && (
-          <section>
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
-              Uploaded Documents
-            </h3>
-            <ul className="space-y-1">
-              {extractedFiles.map((f) => (
-                <li
-                  key={f.name}
-                  className="flex items-center gap-2 rounded-md border border-[#E8E4E0] bg-white px-3 py-2 text-sm text-[var(--ink-black)] shadow-sm"
-                >
-                  <span className="text-green-600" aria-hidden>&#10003;</span>
-                  <span className="truncate">{f.name}</span>
-                  <span className="ml-auto shrink-0 text-[10px] text-[#9A9590]">
-                    {f.text.length.toLocaleString()} chars
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
       </div>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -477,7 +477,6 @@ export default function Home() {
           <InputPanel
             sourceText={sourceText}
             onSourceTextChange={setSourceText}
-            extractedFiles={extractedFiles}
             onFilesChanged={setExtractedFiles}
             contextText={contextText}
             onContextTextChange={setContextText}


### PR DESCRIPTION
## Summary
- **Deduplicated file display**: Uploaded document names were shown twice — once inside the `FileUpload` component (with status indicator and remove button) and again in the parent panel as an "Uploaded Documents" list. Removed the duplicate from `InputPanel` and `SourcePanel`, and added character count display to `FileUpload` for ready files so no info is lost.
- **Fixed input panel scrolling**: Capped the Source Inputs section at `max-h-[50%]` so uploading files can't push the Direct Formalization section (context box + controls) off screen. Both sections scroll independently.
- Cleaned up the now-unused `extractedFiles` prop from `InputPanel` and its test.

## Test plan
- [ ] Upload one or more files — verify each file name appears only once, with status indicator, char count (when ready), and remove button
- [ ] Upload enough files to overflow the Source Inputs area — verify it scrolls and the Direct Formalization section remains visible
- [ ] Remove a file via the ✕ button — verify it disappears
- [ ] Verify the context textarea and Formalise button are always reachable without scrolling past the source section

🤖 Generated with [Claude Code](https://claude.com/claude-code)