### PR TITLE
fix: persist uploaded file display across tab switches

### DIFF
--- a/app/components/features/source-input/FileUpload.tsx
+++ b/app/components/features/source-input/FileUpload.tsx
@@ -17,14 +17,34 @@ type TrackedFile = {
 
 type FileUploadProps = {
   onFilesChanged?: (files: { name: string; text: string; file?: File }[]) => void;
+  /** Previously extracted files to display on mount (e.g. restored from persistence) */
+  existingFiles?: { name: string; text: string }[];
 };
 
-export default function FileUpload({ onFilesChanged }: FileUploadProps) {
+export default function FileUpload({ onFilesChanged, existingFiles }: FileUploadProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [trackedFiles, setTrackedFiles] = useState<TrackedFile[]>([]);
 
-  // Notify parent whenever ready files change
+  // Seed trackedFiles from existingFiles on mount. These entries lack a File object
+  // (it can't be serialized) but still show the user what was previously uploaded.
+  const [trackedFiles, setTrackedFiles] = useState<TrackedFile[]>(() =>
+    (existingFiles ?? []).map((f) => ({
+      file: new File([], f.name), // placeholder — original File can't be persisted
+      status: "ready" as const,
+      text: f.text,
+    })),
+  );
+
+  // Track whether we're still on the initial render to avoid notifying parent
+  // with the same files it already has.
+  const isInitialMount = useRef(true);
+
+  // Notify parent whenever ready files change (skip the initial mount
+  // when we're just restoring existingFiles the parent already knows about)
   useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
     const readyFiles = trackedFiles
       .filter((f) => f.status === "ready")
       .map((f) => ({ name: f.file.name, text: f.text, file: f.file }));

--- a/app/components/panels/InputPanel.tsx
+++ b/app/components/panels/InputPanel.tsx
@@ -8,6 +8,7 @@ type InputPanelProps = {
   sourceText: string;
   onSourceTextChange: (value: string) => void;
   onFilesChanged: (files: { name: string; text: string }[]) => void;
+  existingFiles?: { name: string; text: string }[];
   contextText: string;
   onContextTextChange: (value: string) => void;
   onFormalise: () => void;
@@ -25,6 +26,7 @@ export default function InputPanel({
   sourceText,
   onSourceTextChange,
   onFilesChanged,
+  existingFiles,
   contextText,
   onContextTextChange,
   onFormalise,
@@ -46,7 +48,7 @@ export default function InputPanel({
         </div>
         <div className="flex min-h-0 flex-col gap-3 overflow-auto p-4">
           <TextInput value={sourceText} onChange={onSourceTextChange} />
-          <FileUpload onFilesChanged={onFilesChanged} />
+          <FileUpload onFilesChanged={onFilesChanged} existingFiles={existingFiles} />
 
           {/* Decompose action */}
           {onDecompose && (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -478,6 +478,7 @@ export default function Home() {
             sourceText={sourceText}
             onSourceTextChange={setSourceText}
             onFilesChanged={setExtractedFiles}
+            existingFiles={extractedFiles}
             contextText={contextText}
             onContextTextChange={setContextText}
             onFormalise={handleGenerate}


### PR DESCRIPTION
## Summary
- When switching tabs away from the Source panel and back, the FileUpload component unmounted and remounted, losing its local `trackedFiles` state — making it look like uploaded documents had vanished
- Added `existingFiles` prop to `FileUpload` so it seeds its display from the parent's persisted `extractedFiles` on remount
- Skips re-notifying the parent on initial mount to avoid redundant state updates

## Test plan
- [ ] Upload one or more files on the Source tab
- [ ] Switch to another tab (e.g. Semiformal, Graph) and switch back — uploaded files should still be listed
- [ ] Upload additional files after switching back — they should append to the existing list
- [ ] Remove a restored file — it should disappear and the parent state should update
- [ ] Refresh the page — file names should persist (text content is restored from localStorage; original File objects are not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)