### PR TITLE
feat: restore LLM usage records to analytics tab

### DIFF
--- a/app/api/analytics/route.ts
+++ b/app/api/analytics/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { readAnalyticsEntries, clearAnalyticsEntries } from "@/app/lib/analytics/persist";
+
+export async function GET() {
+  const entries = readAnalyticsEntries();
+  return NextResponse.json({ entries });
+}
+
+export async function DELETE() {
+  clearAnalyticsEntries();
+  return NextResponse.json({ ok: true });
+}

--- a/app/components/panels/AnalyticsPanel.tsx
+++ b/app/components/panels/AnalyticsPanel.tsx
@@ -1,8 +1,9 @@
-import type { EndpointPrior } from "@/app/lib/types/analytics";
-import { computeCost } from "@/app/lib/llm/costs";
+import type { AnalyticsEntry, AnalyticsSummary } from "@/app/lib/types/analytics";
 
 type AnalyticsPanelProps = {
-  endpointPriors: Record<string, EndpointPrior>;
+  entries: AnalyticsEntry[];
+  summary: AnalyticsSummary;
+  onClear: () => void;
 };
 
 function formatCost(usd: number): string {
@@ -22,70 +23,105 @@ function formatLatency(ms: number): string {
   return `${Math.round(ms)}ms`;
 }
 
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
 /** Short endpoint label: "formalization/semiformal" -> "semiformal" */
 function shortEndpoint(endpoint: string): string {
   const parts = endpoint.split("/");
   return parts[parts.length - 1];
 }
 
-export default function AnalyticsPanel({ endpointPriors }: AnalyticsPanelProps) {
+/** Short model label: "anthropic/claude-opus-4.6" -> "claude-opus-4.6" */
+function shortModel(model: string): string {
+  const parts = model.split("/");
+  return parts[parts.length - 1];
+}
+
+export default function AnalyticsPanel({ entries, summary, onClear }: AnalyticsPanelProps) {
   return (
     <div className="flex h-full flex-col overflow-hidden bg-[var(--ivory-cream)]">
       {/* Header */}
       <div className="flex items-center justify-between border-b border-[#DDD9D5] bg-[#F5F1ED] px-6 py-3">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--ink-black)]">
-          LLM Usage Estimates
+          LLM Usage
         </h2>
+        <button
+          onClick={onClear}
+          className="rounded px-2 py-1 text-xs text-[#6B6560] hover:bg-[#E8E4E0] hover:text-[var(--ink-black)]"
+        >
+          Clear Session
+        </button>
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-auto p-6">
-        {/* Typical Ranges table from prior data */}
-        <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
-          Typical Ranges
-        </h3>
-        <div className="overflow-auto rounded border border-[#E8E4E0]">
-          <table className="w-full text-xs font-mono">
-            <thead>
-              <tr className="border-b border-[#E8E4E0] bg-[#F5F1ED] text-left text-[#6B6560]">
-                <th className="px-3 py-2">Endpoint</th>
-                <th className="px-3 py-2 text-right">Data Pts</th>
-                <th className="px-3 py-2 text-right">Output Tokens</th>
-                <th className="px-3 py-2 text-right">Cost Range</th>
-                <th className="px-3 py-2 text-right">Latency Range</th>
-              </tr>
-            </thead>
-            <tbody>
-              {Object.entries(endpointPriors).map(([endpoint, prior]) => {
-                const lowOut = Math.max(50, prior.meanOutputTokens - prior.stddevOutputTokens);
-                const highOut = prior.meanOutputTokens + prior.stddevOutputTokens;
-                const lowLat = Math.max(0, prior.meanLatencyMs - prior.stddevLatencyMs);
-                const highLat = prior.meanLatencyMs + prior.stddevLatencyMs;
-                return (
-                  <tr key={endpoint} className="border-b border-[#F0EBE6] hover:bg-[#F5F1ED]">
-                    <td className="px-3 py-1.5">{shortEndpoint(endpoint)}</td>
-                    <td className="px-3 py-1.5 text-right">
-                      {prior.n === 0 ? (
-                        <span className="text-[#9A9590]">est.</span>
-                      ) : (
-                        prior.n
-                      )}
-                    </td>
-                    <td className="px-3 py-1.5 text-right">
-                      {formatTokens(lowOut)}&ndash;{formatTokens(highOut)}
-                    </td>
-                    <td className="px-3 py-1.5 text-right">
-                      {formatCost(computeCost(prior.model, 0, lowOut))}&ndash;{formatCost(computeCost(prior.model, 0, highOut))}
-                    </td>
-                    <td className="px-3 py-1.5 text-right">
-                      {formatLatency(lowLat)}&ndash;{formatLatency(highLat)}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+        {/* Summary cards */}
+        <div className="mb-6 grid grid-cols-4 gap-3">
+          <SummaryCard label="API Calls" value={String(summary.totalCalls)} />
+          <SummaryCard
+            label="Total Tokens"
+            value={formatTokens(summary.totalInputTokens + summary.totalOutputTokens)}
+          />
+          <SummaryCard label="Est. Cost" value={formatCost(summary.totalCostUsd)} />
+          <SummaryCard label="Avg Latency" value={formatLatency(summary.averageLatencyMs)} />
         </div>
+
+        {/* Detail table */}
+        {entries.length === 0 ? (
+          <p className="text-center text-sm text-[#9A9590]">
+            No LLM calls yet. Use the app to see usage data here.
+          </p>
+        ) : (
+          <div className="overflow-auto rounded border border-[#E8E4E0]">
+            <table className="w-full text-xs font-mono">
+              <thead>
+                <tr className="border-b border-[#E8E4E0] bg-[#F5F1ED] text-left text-[#6B6560]">
+                  <th className="px-3 py-2">Time</th>
+                  <th className="px-3 py-2">Endpoint</th>
+                  <th className="px-3 py-2">Model</th>
+                  <th className="px-3 py-2 text-right">In Tok</th>
+                  <th className="px-3 py-2 text-right">Out Tok</th>
+                  <th className="px-3 py-2 text-right">Cost</th>
+                  <th className="px-3 py-2 text-right">Latency</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[...entries].reverse().map((e) => (
+                  <tr key={e.id} className="border-b border-[#F0EBE6] hover:bg-[#F5F1ED]">
+                    <td className="whitespace-nowrap px-3 py-1.5 text-[#6B6560]">{formatTime(e.timestamp)}</td>
+                    <td className="px-3 py-1.5">{shortEndpoint(e.endpoint)}</td>
+                    <td className="px-3 py-1.5 text-[#6B6560]">{shortModel(e.model)}</td>
+                    <td className="px-3 py-1.5 text-right">{e.inputTokens.toLocaleString()}</td>
+                    <td className="px-3 py-1.5 text-right">{e.outputTokens.toLocaleString()}</td>
+                    <td className="px-3 py-1.5 text-right">{formatCost(e.costUsd)}</td>
+                    <td className="px-3 py-1.5 text-right">{formatLatency(e.latencyMs)}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot>
+                <tr className="border-t border-[#DDD9D5] bg-[#F5F1ED] font-semibold">
+                  <td className="px-3 py-2" colSpan={3}>Total ({entries.length} calls)</td>
+                  <td className="px-3 py-2 text-right">{summary.totalInputTokens.toLocaleString()}</td>
+                  <td className="px-3 py-2 text-right">{summary.totalOutputTokens.toLocaleString()}</td>
+                  <td className="px-3 py-2 text-right">{formatCost(summary.totalCostUsd)}</td>
+                  <td className="px-3 py-2 text-right">{formatLatency(summary.averageLatencyMs)} avg</td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
       </div>
+    </div>
+  );
+}
+
+function SummaryCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-[#E8E4E0] bg-white px-3 py-2 shadow-sm">
+      <div className="text-[10px] uppercase tracking-wide text-[#9A9590]">{label}</div>
+      <div className="mt-0.5 text-lg font-semibold text-[var(--ink-black)]">{value}</div>
     </div>
   );
 }

--- a/app/hooks/useAnalytics.ts
+++ b/app/hooks/useAnalytics.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useCallback, useMemo, useEffect } from "react";
+import type { AnalyticsEntry, AnalyticsSummary } from "@/app/lib/types/analytics";
+
+export function useAnalytics() {
+  const [entries, setEntries] = useState<AnalyticsEntry[]>([]);
+
+  // Hydrate from persisted analytics on mount
+  useEffect(() => {
+    fetch("/api/analytics")
+      .then((res) => res.json())
+      .then((data) => {
+        if (Array.isArray(data.entries) && data.entries.length > 0) {
+          setEntries(data.entries);
+        }
+      })
+      .catch(() => {
+        // Persistence unavailable — continue with empty state
+      });
+  }, []);
+
+  const clearAnalytics = useCallback(() => {
+    setEntries([]);
+    fetch("/api/analytics", { method: "DELETE" }).catch(() => {
+      // Persistence unavailable — local state already cleared
+    });
+  }, []);
+
+  const summary: AnalyticsSummary = useMemo(() => {
+    const totalCalls = entries.length;
+    const totalInputTokens = entries.reduce((s, e) => s + e.inputTokens, 0);
+    const totalOutputTokens = entries.reduce((s, e) => s + e.outputTokens, 0);
+    const totalCostUsd = entries.reduce((s, e) => s + e.costUsd, 0);
+    const averageLatencyMs = totalCalls > 0
+      ? entries.reduce((s, e) => s + e.latencyMs, 0) / totalCalls
+      : 0;
+    return { totalCalls, totalInputTokens, totalOutputTokens, totalCostUsd, averageLatencyMs };
+  }, [entries]);
+
+  return { entries, summary, clearAnalytics };
+}

--- a/app/lib/analytics/persist.ts
+++ b/app/lib/analytics/persist.ts
@@ -1,0 +1,37 @@
+import { appendFileSync, readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import { join } from "path";
+import type { AnalyticsEntry } from "@/app/lib/types/analytics";
+
+const DATA_DIR = join(process.cwd(), "data");
+const FILE_PATH = join(DATA_DIR, "analytics.jsonl");
+
+function ensureDir() {
+  if (!existsSync(DATA_DIR)) {
+    mkdirSync(DATA_DIR, { recursive: true });
+  }
+}
+
+export function appendAnalyticsEntry(entry: AnalyticsEntry): void {
+  ensureDir();
+  appendFileSync(FILE_PATH, JSON.stringify(entry) + "\n", "utf-8");
+}
+
+export function readAnalyticsEntries(): AnalyticsEntry[] {
+  if (!existsSync(FILE_PATH)) return [];
+  const content = readFileSync(FILE_PATH, "utf-8");
+  const entries: AnalyticsEntry[] = [];
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      entries.push(JSON.parse(line));
+    } catch {
+      // skip corrupt lines
+    }
+  }
+  return entries;
+}
+
+export function clearAnalyticsEntries(): void {
+  ensureDir();
+  writeFileSync(FILE_PATH, "", "utf-8");
+}

--- a/app/lib/llm/callLlm.ts
+++ b/app/lib/llm/callLlm.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from "crypto";
 import Anthropic from "@anthropic-ai/sdk";
 import { computeCost } from "./costs";
+import { appendAnalyticsEntry } from "@/app/lib/analytics/persist";
 import { computeHash, getCachedResult, setCachedResult } from "./cache";
 
 const OPENROUTER_API_URL = "https://openrouter.ai/api/v1/chat/completions";
@@ -108,6 +110,14 @@ export async function callLlm({
       costUsd: computeCost(model, inputTokens, outputTokens),
       latencyMs,
     };
+    try {
+      appendAnalyticsEntry({
+        id: randomUUID(),
+        endpoint,
+        ...usage,
+        timestamp: new Date().toISOString(),
+      });
+    } catch { /* persistence failure must not break LLM calls */ }
     const cacheKey: CacheKey = { model: effectiveModel, systemPrompt, userContent, maxTokens };
     const result = { text, usage, cacheKey };
     if (text) {
@@ -152,6 +162,14 @@ export async function callLlm({
       costUsd: computeCost(openRouterModel, inputTokens, outputTokens),
       latencyMs,
     };
+    try {
+      appendAnalyticsEntry({
+        id: randomUUID(),
+        endpoint,
+        ...usage,
+        timestamp: new Date().toISOString(),
+      });
+    } catch { /* persistence failure must not break LLM calls */ }
     const cacheKey: CacheKey = { model: effectiveModel, systemPrompt, userContent, maxTokens };
     const result = { text, usage, cacheKey };
     if (text) {
@@ -170,5 +188,13 @@ export async function callLlm({
     costUsd: 0,
     latencyMs: 0,
   };
+  try {
+    appendAnalyticsEntry({
+      id: randomUUID(),
+      endpoint,
+      ...usage,
+      timestamp: new Date().toISOString(),
+    });
+  } catch { /* persistence failure must not break LLM calls */ }
   return { text: "", usage };
 }

--- a/app/lib/types/analytics.ts
+++ b/app/lib/types/analytics.ts
@@ -15,6 +15,27 @@ export type EndpointPrior = {
   model: string;
 };
 
+export type LlmUsage = {
+  endpoint: string;
+  model: string;
+  provider: "anthropic" | "openrouter" | "mock" | "cache";
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  latencyMs: number;
+  timestamp: string; // ISO
+};
+
+export type AnalyticsEntry = LlmUsage & { id: string };
+
+export type AnalyticsSummary = {
+  totalCalls: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCostUsd: number;
+  averageLatencyMs: number;
+};
+
 export type CallPrediction = {
   endpoint: string;
   estimatedInputTokens: number;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ import { useFormalizationPipeline } from "@/app/hooks/useFormalizationPipeline";
 import { useActiveArtifactState } from "@/app/hooks/useActiveArtifactState";
 import { usePanelDefinitions } from "@/app/hooks/usePanelDefinitions";
 import { useArtifactGeneration } from "@/app/hooks/useArtifactGeneration";
-import { ENDPOINT_PRIORS } from "@/app/lib/llm/predict";
+import { useAnalytics } from "@/app/hooks/useAnalytics";
 import { gatherDependencyContext } from "@/app/lib/utils/leanContext";
 
 export default function Home() {
@@ -78,6 +78,9 @@ export default function Home() {
   // --- Artifact type selection + parallel generation ---
   const [selectedArtifactTypes, setSelectedArtifactTypes] = useState<ArtifactType[]>([]);
   const { loadingState: artifactLoadingState, generateArtifacts, isAnyGenerating } = useArtifactGeneration();
+
+  // --- Analytics ---
+  const { entries: analyticsEntries, summary: analyticsSummary, clearAnalytics } = useAnalytics();
 
   // Derive per-type loading booleans from artifactLoadingState
   const causalGraphLoading = artifactLoadingState["causal-graph"] === "generating";
@@ -577,7 +580,7 @@ export default function Home() {
           />
         );
       case "analytics":
-        return <AnalyticsPanel endpointPriors={ENDPOINT_PRIORS} />;
+        return <AnalyticsPanel entries={analyticsEntries} summary={analyticsSummary} onClear={clearAnalytics} />;
       default:
         return undefined;
     }
@@ -597,6 +600,7 @@ export default function Home() {
     statisticalModel, statisticalModelLoading,
     propertyTests, propertyTestsLoading,
     dialecticalMap, dialecticalMapLoading,
+    analyticsEntries, analyticsSummary, clearAnalytics,
   ]);
 
   return (


### PR DESCRIPTION
## Summary
- Restores per-call LLM usage tracking that was removed in 18ff643 after initial data collection
- Every LLM call (Anthropic, OpenRouter, mock) now persists to `data/analytics.jsonl` via `appendAnalyticsEntry` in `callLlm.ts`
- Analytics tab shows actual usage data: summary cards (API Calls, Total Tokens, Est. Cost, Avg Latency) + per-call detail table with Clear Session button

## Changes
- **`app/lib/analytics/persist.ts`** (new) — JSONL file persistence (append/read/clear)
- **`app/api/analytics/route.ts`** (new) — GET and DELETE endpoints for analytics entries
- **`app/hooks/useAnalytics.ts`** (new) — React hook that hydrates from `/api/analytics` on mount
- **`app/lib/types/analytics.ts`** — Added `LlmUsage`, `AnalyticsEntry`, `AnalyticsSummary` types
- **`app/lib/llm/callLlm.ts`** — Re-added `appendAnalyticsEntry` calls after each provider path
- **`app/components/panels/AnalyticsPanel.tsx`** — Replaced prediction-based display with actual usage records
- **`app/page.tsx`** — Wired up `useAnalytics` hook to pass data to AnalyticsPanel

## Test plan
- [ ] Make an LLM call (e.g. generate semiformal) and verify the analytics tab shows the call with correct tokens/cost/latency
- [ ] Verify summary cards update after multiple calls
- [ ] Verify "Clear Session" button clears all entries and the `data/analytics.jsonl` file
- [ ] Verify analytics persist across page refreshes (hydrated from JSONL on mount)
- [ ] Verify cache hits are not double-counted (only non-cached calls are recorded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)