### PR TITLE
fix: rename Proof Graph title to Decomposition

### DIFF
--- a/app/components/panels/GraphPanel.tsx
+++ b/app/components/panels/GraphPanel.tsx
@@ -87,7 +87,7 @@ export default function GraphPanel({
     <div className="flex h-full flex-col overflow-hidden bg-[var(--ivory-cream)]">
       <div className="flex items-center justify-between border-b border-[#DDD9D5] bg-[#F5F1ED] px-6 py-3">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--ink-black)]">
-          Proof Graph
+          Decomposition
         </h2>
         <div className="flex items-center gap-2">
           {hasNodes && (


### PR DESCRIPTION
## Summary
- Renamed the "Proof Graph" header text to "Decomposition" in the graph panel, matching the intended terminology from decision doc 002.

## Test plan
- [ ] Open the decomposition tab and verify the header reads "Decomposition" instead of "Proof Graph"

🤖 Generated with [Claude Code](https://claude.com/claude-code)