### PR TITLE
feat: export new formalisms (dialectic, causal graph, stats)

### DIFF
--- a/app/lib/utils/exportAll.ts
+++ b/app/lib/utils/exportAll.ts
@@ -5,6 +5,10 @@
 
 import JSZip from "jszip";
 import type { PropositionNode } from "@/app/lib/types/decomposition";
+import type { CausalGraphResponse } from "@/app/lib/types/artifacts";
+import type { StatisticalModelResponse } from "@/app/lib/types/artifacts";
+import type { PropertyTestsResponse } from "@/app/lib/types/artifacts";
+import type { DialecticalMapResponse } from "@/app/lib/types/artifacts";
 import { sanitizeFilename, triggerDownload } from "./export";
 import { getGraphViewportElement, graphToPngBlob } from "./exportGraph";
 
@@ -12,12 +16,20 @@ type ExportAllOptions = {
   semiformalText: string;
   leanCode: string;
   nodes: PropositionNode[];
+  causalGraph?: CausalGraphResponse["causalGraph"] | null;
+  statisticalModel?: StatisticalModelResponse["statisticalModel"] | null;
+  propertyTests?: PropertyTestsResponse["propertyTests"] | null;
+  dialecticalMap?: DialecticalMapResponse["dialecticalMap"] | null;
 };
 
 export async function exportAllAsZip({
   semiformalText,
   leanCode,
   nodes,
+  causalGraph,
+  statisticalModel,
+  propertyTests,
+  dialecticalMap,
 }: ExportAllOptions) {
   const zip = new JSZip();
 
@@ -27,6 +39,20 @@ export async function exportAllAsZip({
   }
   if (leanCode.trim()) {
     zip.file("proof.lean", leanCode);
+  }
+
+  // New formalism artifacts
+  if (causalGraph) {
+    zip.file("causal-graph.json", JSON.stringify(causalGraph, null, 2));
+  }
+  if (statisticalModel) {
+    zip.file("statistical-model.json", JSON.stringify(statisticalModel, null, 2));
+  }
+  if (propertyTests) {
+    zip.file("property-tests.json", JSON.stringify(propertyTests, null, 2));
+  }
+  if (dialecticalMap) {
+    zip.file("dialectical-map.json", JSON.stringify(dialecticalMap, null, 2));
   }
 
   // Graph screenshot (best-effort)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -452,7 +452,10 @@ export default function Home() {
   });
 
   // --- Export All handler ---
-  const hasExportableContent = Boolean(semiformalText.trim() || leanCode.trim() || decomp.nodes.length > 0);
+  const hasExportableContent = Boolean(
+    semiformalText.trim() || leanCode.trim() || decomp.nodes.length > 0
+    || causalGraph || statisticalModel || propertyTests || dialecticalMap
+  );
 
   const handleExportAll = useCallback(async () => {
     // Dynamic import so jszip is only loaded when user clicks Export All
@@ -461,8 +464,12 @@ export default function Home() {
       semiformalText,
       leanCode,
       nodes: decomp.nodes,
+      causalGraph,
+      statisticalModel,
+      propertyTests,
+      dialecticalMap,
     });
-  }, [semiformalText, leanCode, decomp.nodes]);
+  }, [semiformalText, leanCode, decomp.nodes, causalGraph, statisticalModel, propertyTests, dialecticalMap]);
 
   // --- Panel render function (only creates JSX for the active panel) ---
   const renderPanel = useCallback((panelId: PanelId): React.ReactNode => {


### PR DESCRIPTION
## Summary
- Export All now includes causal graph, statistical model, property tests, and dialectical map as pretty-printed JSON files in the zip bundle
- Export All button enables when any of these new artifacts are present (previously only checked semiformal/Lean/nodes)
- No changes to existing export behavior — semiformal, Lean, graph screenshot, and per-node artifacts are unchanged

## Test plan
- [ ] Generate a causal graph, statistical model, property tests, or dialectical map
- [ ] Click Export All — verify the zip contains the corresponding `.json` files with readable content
- [ ] Verify Export All button is enabled when only new-formalism artifacts exist (no semiformal/Lean)
- [ ] Verify existing exports (semiformal `.md`, Lean `.lean`, graph PNG, per-node folders) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)