### PR TITLE
feat: add graph visualization to causal graph panel

### DIFF
--- a/app/components/features/causal-graph/CausalGraphNode.tsx
+++ b/app/components/features/causal-graph/CausalGraphNode.tsx
@@ -1,0 +1,43 @@
+import { memo } from "react";
+import { Handle, Position } from "reactflow";
+import type { NodeProps } from "reactflow";
+
+export type CausalNodeData = {
+  id: string;
+  label: string;
+  description: string;
+  isConfounder: boolean;
+};
+
+function CausalGraphNode({ data }: NodeProps<CausalNodeData>) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center rounded-lg border bg-white px-3 py-2 shadow-sm transition-shadow hover:shadow-md"
+      style={{
+        borderColor: data.isConfounder ? "#D97706" : "#9A9590",
+        borderWidth: 2,
+        minWidth: 160,
+      }}
+    >
+      <Handle type="target" position={Position.Top} className="!bg-[#9A9590]" />
+
+      {data.isConfounder && (
+        <span className="rounded px-1.5 py-0.5 text-[10px] font-bold uppercase text-white bg-amber-600">
+          confounder
+        </span>
+      )}
+
+      <span className="mt-1 text-center text-xs font-semibold text-[var(--ink-black)]">
+        {data.label}
+      </span>
+
+      <span className="mt-0.5 text-center text-[9px] text-[#6B6560] line-clamp-2">
+        {data.description}
+      </span>
+
+      <Handle type="source" position={Position.Bottom} className="!bg-[#9A9590]" />
+    </div>
+  );
+}
+
+export default memo(CausalGraphNode);

--- a/app/components/features/causal-graph/CausalGraphView.tsx
+++ b/app/components/features/causal-graph/CausalGraphView.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import ReactFlow, { Background, Controls, type NodeMouseHandler } from "reactflow";
+import "reactflow/dist/style.css";
+import type { CausalGraphResponse } from "@/app/lib/types/artifacts";
+import CausalGraphNode from "./CausalGraphNode";
+import { useCausalGraphLayout } from "./useCausalGraphLayout";
+
+const nodeTypes = { causalNode: CausalGraphNode };
+
+type CausalGraphViewProps = {
+  causalGraph: CausalGraphResponse["causalGraph"];
+  onSelectVariable?: (id: string) => void;
+};
+
+export default function CausalGraphView({ causalGraph, onSelectVariable }: CausalGraphViewProps) {
+  const { nodes, edges } = useCausalGraphLayout(causalGraph);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const handleNodeClick: NodeMouseHandler = useCallback(
+    (_event, node) => {
+      setSelectedId(node.id);
+      onSelectVariable?.(node.id);
+    },
+    [onSelectVariable],
+  );
+
+  return (
+    <div className="h-full w-full">
+      <ReactFlow
+        nodes={nodes.map((n) => ({
+          ...n,
+          selected: n.id === selectedId,
+        }))}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        onNodeClick={handleNodeClick}
+        fitView
+        fitViewOptions={{ padding: 0.2 }}
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.3}
+        maxZoom={2}
+      >
+        <Background color="#DDD9D5" gap={20} />
+        <Controls
+          showInteractive={false}
+          className="!bg-white !border-[#DDD9D5] !shadow-sm"
+        />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/app/components/features/causal-graph/useCausalGraphLayout.ts
+++ b/app/components/features/causal-graph/useCausalGraphLayout.ts
@@ -1,0 +1,75 @@
+import { useMemo } from "react";
+import dagre from "dagre";
+import type { Node, Edge } from "reactflow";
+import type { CausalGraphResponse } from "@/app/lib/types/artifacts";
+import type { CausalNodeData } from "./CausalGraphNode";
+
+const NODE_WIDTH = 180;
+const NODE_HEIGHT = 70;
+
+/**
+ * Convert CausalGraphResponse data into ReactFlow nodes + edges using Dagre layout.
+ * Variables become nodes; causal edges become directed edges with weight-based styling.
+ * Confounders are marked on matching variable nodes.
+ */
+export function useCausalGraphLayout(
+  causalGraph: CausalGraphResponse["causalGraph"] | null,
+) {
+  return useMemo(() => {
+    if (!causalGraph || causalGraph.variables.length === 0)
+      return { nodes: [], edges: [] };
+
+    const confounderIds = new Set(causalGraph.confounders.map((c) => c.id));
+
+    const g = new dagre.graphlib.Graph();
+    g.setDefaultEdgeLabel(() => ({}));
+    g.setGraph({ rankdir: "TB", nodesep: 50, ranksep: 70 });
+
+    for (const v of causalGraph.variables) {
+      g.setNode(v.id, { width: NODE_WIDTH, height: NODE_HEIGHT });
+    }
+
+    const edges: Edge[] = [];
+    for (const e of causalGraph.edges) {
+      const edgeId = `${e.from}->${e.to}`;
+      g.setEdge(e.from, e.to);
+
+      // Color by weight direction, thickness by magnitude
+      const abs = Math.abs(e.weight);
+      const strokeColor = e.weight >= 0 ? "#059669" : "#DC2626";
+      const strokeWidth = abs > 0.7 ? 3 : abs > 0.3 ? 2 : 1;
+
+      edges.push({
+        id: edgeId,
+        source: e.from,
+        target: e.to,
+        style: { stroke: strokeColor, strokeWidth },
+        label: e.weight.toFixed(2),
+        labelStyle: { fontSize: 10, fill: strokeColor },
+        animated: abs > 0.7,
+      });
+    }
+
+    dagre.layout(g);
+
+    const nodes: Node<CausalNodeData>[] = causalGraph.variables.map((v) => {
+      const pos = g.node(v.id);
+      return {
+        id: v.id,
+        type: "causalNode",
+        position: {
+          x: (pos?.x ?? 0) - NODE_WIDTH / 2,
+          y: (pos?.y ?? 0) - NODE_HEIGHT / 2,
+        },
+        data: {
+          id: v.id,
+          label: v.label,
+          description: v.description,
+          isConfounder: confounderIds.has(v.id),
+        },
+      };
+    });
+
+    return { nodes, edges };
+  }, [causalGraph]);
+}

--- a/app/components/panels/CausalGraphPanel.tsx
+++ b/app/components/panels/CausalGraphPanel.tsx
@@ -1,12 +1,16 @@
 "use client";
 
+import { useState } from "react";
 import type { CausalGraphResponse } from "@/app/lib/types/artifacts";
 import ArtifactPanelShell from "./ArtifactPanelShell";
+import CausalGraphView from "@/app/components/features/causal-graph/CausalGraphView";
 
 type CausalGraphPanelProps = {
   causalGraph: CausalGraphResponse["causalGraph"] | null;
   loading?: boolean;
 };
+
+type ViewMode = "graph" | "details";
 
 function WeightBadge({ weight }: { weight: number }) {
   const abs = Math.abs(weight);
@@ -19,7 +23,78 @@ function WeightBadge({ weight }: { weight: number }) {
   );
 }
 
+function DetailsView({ causalGraph }: { causalGraph: CausalGraphResponse["causalGraph"] }) {
+  return (
+    <>
+      {/* Summary */}
+      <section>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">Summary</h3>
+        <p className="text-sm text-[var(--ink-black)] leading-relaxed">{causalGraph.summary}</p>
+      </section>
+
+      {/* Variables */}
+      <section>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">
+          Variables ({causalGraph.variables.length})
+        </h3>
+        <div className="space-y-2">
+          {causalGraph.variables.map((v) => (
+            <div key={v.id} className="rounded border border-[#DDD9D5] bg-white px-3 py-2">
+              <div className="flex items-center gap-2">
+                <span className="font-mono text-xs text-[#9A9590]">{v.id}</span>
+                <span className="text-sm font-medium text-[var(--ink-black)]">{v.label}</span>
+              </div>
+              <p className="mt-1 text-xs text-[#6B6560]">{v.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Edges */}
+      <section>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">
+          Causal Edges ({causalGraph.edges.length})
+        </h3>
+        <div className="space-y-2">
+          {causalGraph.edges.map((e, i) => (
+            <div key={`${e.from}-${e.to}-${i}`} className="rounded border border-[#DDD9D5] bg-white px-3 py-2">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-mono text-xs">{e.from}</span>
+                <span className="text-[#9A9590]">&rarr;</span>
+                <span className="font-mono text-xs">{e.to}</span>
+                <WeightBadge weight={e.weight} />
+              </div>
+              <p className="mt-1 text-xs text-[#6B6560]">{e.mechanism}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Confounders */}
+      {causalGraph.confounders.length > 0 && (
+        <section>
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">
+            Confounders ({causalGraph.confounders.length})
+          </h3>
+          <div className="space-y-2">
+            {causalGraph.confounders.map((c) => (
+              <div key={c.id} className="rounded border border-amber-200 bg-amber-50 px-3 py-2">
+                <span className="text-sm font-medium text-amber-900">{c.label}</span>
+                <p className="mt-1 text-xs text-amber-700">
+                  Affects: {c.affectedEdges.join(", ")}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </>
+  );
+}
+
 export default function CausalGraphPanel({ causalGraph, loading }: CausalGraphPanelProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>("graph");
+
   return (
     <ArtifactPanelShell
       title="Causal Graph"
@@ -29,70 +104,39 @@ export default function CausalGraphPanel({ causalGraph, loading }: CausalGraphPa
       loadingMessage="Generating causal graph..."
     >
       {causalGraph && (
-        <>
-          {/* Summary */}
-          <section>
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">Summary</h3>
-            <p className="text-sm text-[var(--ink-black)] leading-relaxed">{causalGraph.summary}</p>
-          </section>
+        <div className="flex flex-col h-full">
+          {/* View toggle */}
+          <div className="flex gap-1 mb-3">
+            <button
+              onClick={() => setViewMode("graph")}
+              className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+                viewMode === "graph"
+                  ? "bg-[var(--ink-black)] text-white"
+                  : "bg-[#F5F1ED] text-[#6B6560] hover:bg-[#E8E4E0]"
+              }`}
+            >
+              Graph
+            </button>
+            <button
+              onClick={() => setViewMode("details")}
+              className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
+                viewMode === "details"
+                  ? "bg-[var(--ink-black)] text-white"
+                  : "bg-[#F5F1ED] text-[#6B6560] hover:bg-[#E8E4E0]"
+              }`}
+            >
+              Details
+            </button>
+          </div>
 
-          {/* Variables */}
-          <section>
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">
-              Variables ({causalGraph.variables.length})
-            </h3>
-            <div className="space-y-2">
-              {causalGraph.variables.map((v) => (
-                <div key={v.id} className="rounded border border-[#DDD9D5] bg-white px-3 py-2">
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-xs text-[#9A9590]">{v.id}</span>
-                    <span className="text-sm font-medium text-[var(--ink-black)]">{v.label}</span>
-                  </div>
-                  <p className="mt-1 text-xs text-[#6B6560]">{v.description}</p>
-                </div>
-              ))}
+          {viewMode === "graph" ? (
+            <div className="flex-1 min-h-[400px]">
+              <CausalGraphView causalGraph={causalGraph} />
             </div>
-          </section>
-
-          {/* Edges */}
-          <section>
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">
-              Causal Edges ({causalGraph.edges.length})
-            </h3>
-            <div className="space-y-2">
-              {causalGraph.edges.map((e, i) => (
-                <div key={`${e.from}-${e.to}-${i}`} className="rounded border border-[#DDD9D5] bg-white px-3 py-2">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-mono text-xs">{e.from}</span>
-                    <span className="text-[#9A9590]">&rarr;</span>
-                    <span className="font-mono text-xs">{e.to}</span>
-                    <WeightBadge weight={e.weight} />
-                  </div>
-                  <p className="mt-1 text-xs text-[#6B6560]">{e.mechanism}</p>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          {/* Confounders */}
-          {causalGraph.confounders.length > 0 && (
-            <section>
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">
-                Confounders ({causalGraph.confounders.length})
-              </h3>
-              <div className="space-y-2">
-                {causalGraph.confounders.map((c) => (
-                  <div key={c.id} className="rounded border border-amber-200 bg-amber-50 px-3 py-2">
-                    <span className="text-sm font-medium text-amber-900">{c.label}</span>
-                    <p className="mt-1 text-xs text-amber-700">
-                      Affects: {c.affectedEdges.join(", ")}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </section>
+          ) : (
+            <DetailsView causalGraph={causalGraph} />
           )}
-        </>
+        </div>
       )}
     </ArtifactPanelShell>
   );


### PR DESCRIPTION
## Summary
- Reuses the same Dagre + ReactFlow pattern from the decomposition tab's ProofGraph to render causal graph variables as interactive nodes and causal edges as directed connections
- Edge color indicates direction (green = positive, red = negative), thickness indicates weight magnitude, and strong edges (>0.7) animate
- Confounders are highlighted with amber borders and a badge
- Panel defaults to graph view with a toggle to switch to the original details list view

## Test plan
- [ ] Generate a causal graph from source text and verify the graph view renders with nodes and edges
- [ ] Verify edge colors match weight direction (green positive, red negative) and thickness scales with magnitude
- [ ] Verify confounders display with amber border and "confounder" badge
- [ ] Toggle to "Details" view and confirm the original list view still works
- [ ] Toggle back to "Graph" and confirm it re-renders correctly
- [ ] Test with graphs of varying sizes (few variables vs many) to check Dagre layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)