### PR TITLE
fix: remove stale TextInput helper text test

### DIFF
--- a/app/components/features/source-input/TextInput.test.tsx
+++ b/app/components/features/source-input/TextInput.test.tsx
@@ -14,11 +14,6 @@ describe('TextInput', () => {
     expect(screen.getByPlaceholderText('Paste or type your source material here...')).toBeInTheDocument()
   })
 
-  it('shows helper text', () => {
-    render(<TextInput value="" onChange={() => {}} />)
-    expect(screen.getByText(/Enter source information/)).toBeInTheDocument()
-  })
-
   it('calls onChange when user types', async () => {
     const onChange = vi.fn()
     render(<TextInput value="" onChange={onChange} />)


### PR DESCRIPTION
## Summary
- Removed an outdated test case in `TextInput.test.tsx` that expected helper text ("Enter source information") which the component no longer renders
- This was the only failing test; all 153 tests now pass

## Test plan
- [x] `npm test` passes (17 files, 153 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)