### PR TITLE
fix: rename "dialectical map" to "balanced perspectives"

### DIFF
--- a/app/api/formalization/perspective-balance/route.ts
+++ b/app/api/formalization/perspective-balance/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { handleArtifactRoute } from "@/app/lib/formalization/artifactRoute";
 
-const SYSTEM_PROMPT = `You are a dialectical analyst. Given source text and optional context, map the dialectical structure: identify distinct perspectives, their core claims and supporting arguments, tensions between perspectives, and synthesize an equilibrium position.
+const SYSTEM_PROMPT = `You are a perspective analyst. Given source text and optional context, map the balance of perspectives: identify distinct perspectives, their core claims and supporting arguments, tensions between perspectives, and synthesize an equilibrium position.
 
 Return a JSON object with this exact shape:
 {
@@ -30,7 +30,7 @@ Return a JSON object with this exact shape:
       }
     ]
   },
-  "summary": "string (2-4 sentence summary of the dialectical landscape)"
+  "summary": "string (2-4 sentence summary of the perspective landscape)"
 }
 
 Important:
@@ -73,15 +73,15 @@ function mockResponse(sourceText: string) {
         { perspectiveId: "perspective-b", resolution: "Empirical gap addressed by identifying testable predictions" },
       ],
     },
-    summary: "Mock dialectical map with two opposing perspectives and a synthesis.",
+    summary: "Mock balanced perspectives with two opposing viewpoints and a synthesis.",
   };
 }
 
 export async function POST(request: NextRequest) {
   return handleArtifactRoute(request, {
-    endpoint: "formalization/dialectical-map",
+    endpoint: "formalization/perspective-balance",
     systemPrompt: SYSTEM_PROMPT,
-    responseKey: "dialecticalMap",
+    responseKey: "perspectiveBalance",
     mockResponse,
   });
 }

--- a/app/components/panels/PerspectiveBalancePanel.tsx
+++ b/app/components/panels/PerspectiveBalancePanel.tsx
@@ -1,43 +1,43 @@
 "use client";
 
-import type { DialecticalMapResponse } from "@/app/lib/types/artifacts";
+import type { PerspectiveBalanceResponse } from "@/app/lib/types/artifacts";
 import ArtifactPanelShell from "./ArtifactPanelShell";
 
-type DialecticalMapPanelProps = {
-  dialecticalMap: DialecticalMapResponse["dialecticalMap"] | null;
+type PerspectiveBalancePanelProps = {
+  perspectiveBalance: PerspectiveBalanceResponse["perspectiveBalance"] | null;
   loading?: boolean;
 };
 
-export default function DialecticalMapPanel({ dialecticalMap, loading }: DialecticalMapPanelProps) {
+export default function PerspectiveBalancePanel({ perspectiveBalance, loading }: PerspectiveBalancePanelProps) {
   return (
     <ArtifactPanelShell
-      title="Dialectical Map"
+      title="Balanced Perspectives"
       loading={loading}
-      hasData={dialecticalMap !== null}
-      emptyMessage="No dialectical map yet. Generate one from the source panel or node detail."
-      loadingMessage="Generating dialectical map..."
+      hasData={perspectiveBalance !== null}
+      emptyMessage="No balanced perspectives yet. Generate one from the source panel or node detail."
+      loadingMessage="Generating balanced perspectives..."
     >
-      {dialecticalMap && (
+      {perspectiveBalance && (
         <>
           {/* Topic */}
           <section>
             <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">Topic</h3>
-            <p className="text-sm font-medium text-[var(--ink-black)]">{dialecticalMap.topic}</p>
+            <p className="text-sm font-medium text-[var(--ink-black)]">{perspectiveBalance.topic}</p>
           </section>
 
           {/* Summary */}
           <section>
             <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">Summary</h3>
-            <p className="text-sm text-[var(--ink-black)] leading-relaxed">{dialecticalMap.summary}</p>
+            <p className="text-sm text-[var(--ink-black)] leading-relaxed">{perspectiveBalance.summary}</p>
           </section>
 
           {/* Perspectives */}
           <section>
             <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">
-              Perspectives ({dialecticalMap.perspectives.length})
+              Perspectives ({perspectiveBalance.perspectives.length})
             </h3>
             <div className="space-y-3">
-              {dialecticalMap.perspectives.map((p) => (
+              {perspectiveBalance.perspectives.map((p) => (
                 <div key={p.id} className="rounded border border-[#DDD9D5] bg-white px-3 py-2 space-y-2">
                   <div className="flex items-center gap-2">
                     <span className="font-mono text-xs text-[#9A9590]">{p.id}</span>
@@ -72,13 +72,13 @@ export default function DialecticalMapPanel({ dialecticalMap, loading }: Dialect
           </section>
 
           {/* Tensions */}
-          {dialecticalMap.tensions.length > 0 && (
+          {perspectiveBalance.tensions.length > 0 && (
             <section>
               <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">
-                Tensions ({dialecticalMap.tensions.length})
+                Tensions ({perspectiveBalance.tensions.length})
               </h3>
               <div className="space-y-2">
-                {dialecticalMap.tensions.map((t, i) => (
+                {perspectiveBalance.tensions.map((t, i) => (
                   <div key={i} className="rounded border border-red-200 bg-red-50 px-3 py-2">
                     <div className="flex items-center gap-1 text-xs font-mono text-red-700">
                       <span>{t.between[0]}</span>
@@ -96,10 +96,10 @@ export default function DialecticalMapPanel({ dialecticalMap, loading }: Dialect
           <section>
             <h3 className="text-xs font-semibold uppercase tracking-wide text-[#6B6560] mb-2">Synthesis</h3>
             <div className="rounded border border-green-200 bg-green-50 px-3 py-2 space-y-2">
-              <p className="text-sm text-green-900">{dialecticalMap.synthesis.equilibrium}</p>
-              {dialecticalMap.synthesis.howAddressed.length > 0 && (
+              <p className="text-sm text-green-900">{perspectiveBalance.synthesis.equilibrium}</p>
+              {perspectiveBalance.synthesis.howAddressed.length > 0 && (
                 <div className="space-y-1">
-                  {dialecticalMap.synthesis.howAddressed.map((h) => (
+                  {perspectiveBalance.synthesis.howAddressed.map((h) => (
                     <div key={h.perspectiveId} className="text-xs text-green-800">
                       <span className="font-mono font-semibold">{h.perspectiveId}:</span>{" "}
                       {h.resolution}

--- a/app/components/ui/icons/PanelIcons.tsx
+++ b/app/components/ui/icons/PanelIcons.tsx
@@ -106,8 +106,8 @@ export function PropertyTestsIcon({ className }: IconProps) {
   );
 }
 
-/** Scales/balance icon for Dialectical Map */
-export function DialecticalMapIcon({ className }: IconProps) {
+/** Scales/balance icon for Balanced Perspectives */
+export function PerspectiveBalanceIcon({ className }: IconProps) {
   return (
     <svg className={className} width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
       <line x1="10" y1="2" x2="10" y2="18" />

--- a/app/hooks/usePanelDefinitions.tsx
+++ b/app/hooks/usePanelDefinitions.tsx
@@ -11,7 +11,7 @@ import {
   CausalGraphIcon,
   StatisticalModelIcon,
   PropertyTestsIcon,
-  DialecticalMapIcon,
+  PerspectiveBalanceIcon,
   AnalyticsIcon,
 } from "@/app/components/ui/icons/PanelIcons";
 
@@ -32,8 +32,8 @@ type PanelDefsInput = {
   statisticalModelLoading?: boolean;
   hasPropertyTests?: boolean;
   propertyTestsLoading?: boolean;
-  hasDialecticalMap?: boolean;
-  dialecticalMapLoading?: boolean;
+  hasPerspectiveBalance?: boolean;
+  perspectiveBalanceLoading?: boolean;
 };
 
 export function usePanelDefinitions(opts: PanelDefsInput): PanelDef[] {
@@ -45,7 +45,7 @@ export function usePanelDefinitions(opts: PanelDefsInput): PanelDef[] {
     hasCausalGraph, causalGraphLoading,
     hasStatisticalModel, statisticalModelLoading,
     hasPropertyTests, propertyTestsLoading,
-    hasDialecticalMap, dialecticalMapLoading,
+    hasPerspectiveBalance, perspectiveBalanceLoading,
   } = opts;
 
   const hasDecomp = nodes.length > 0;
@@ -137,12 +137,12 @@ export function usePanelDefinitions(opts: PanelDefsInput): PanelDef[] {
       hidden: !hasPropertyTests && !propertyTestsLoading,
     },
     {
-      id: "dialectical-map" as PanelId,
-      label: "Dialectical Map",
-      icon: <DialecticalMapIcon />,
+      id: "perspective-balance" as PanelId,
+      label: "Balanced Perspectives",
+      icon: <PerspectiveBalanceIcon />,
       group: "artifacts" as const,
-      statusSummary: dialecticalMapLoading ? "Generating..." : hasDialecticalMap ? "Map ready" : "No map yet",
-      hidden: !hasDialecticalMap && !dialecticalMapLoading,
+      statusSummary: perspectiveBalanceLoading ? "Generating..." : hasPerspectiveBalance ? "Perspectives ready" : "No perspectives yet",
+      hidden: !hasPerspectiveBalance && !perspectiveBalanceLoading,
     },
     // --- Meta group ---
     {
@@ -157,5 +157,5 @@ export function usePanelDefinitions(opts: PanelDefsInput): PanelDef[] {
       hasCausalGraph, causalGraphLoading,
       hasStatisticalModel, statisticalModelLoading,
       hasPropertyTests, propertyTestsLoading,
-      hasDialecticalMap, dialecticalMapLoading]);
+      hasPerspectiveBalance, perspectiveBalanceLoading]);
 }

--- a/app/hooks/useWorkspacePersistence.ts
+++ b/app/hooks/useWorkspacePersistence.ts
@@ -18,7 +18,7 @@ type WorkspaceState = {
   causalGraph: string | null;
   statisticalModel: string | null;
   propertyTests: string | null;
-  dialecticalMap: string | null;
+  perspectiveBalance: string | null;
 };
 
 const DEFAULT_STATE: WorkspaceState = {
@@ -33,7 +33,7 @@ const DEFAULT_STATE: WorkspaceState = {
   causalGraph: null,
   statisticalModel: null,
   propertyTests: null,
-  dialecticalMap: null,
+  perspectiveBalance: null,
 };
 
 export function useWorkspacePersistence() {
@@ -69,7 +69,7 @@ export function useWorkspacePersistence() {
       causalGraph: data.causalGraph,
       statisticalModel: data.statisticalModel,
       propertyTests: data.propertyTests,
-      dialecticalMap: data.dialecticalMap,
+      perspectiveBalance: data.perspectiveBalance,
     });
 
     decompRef.current = data.decomposition;
@@ -86,8 +86,8 @@ export function useWorkspacePersistence() {
     causalGraph: state.causalGraph,
     statisticalModel: state.statisticalModel,
     propertyTests: state.propertyTests,
-    dialecticalMap: state.dialecticalMap,
-  }), [state.causalGraph, state.statisticalModel, state.propertyTests, state.dialecticalMap]);
+    perspectiveBalance: state.perspectiveBalance,
+  }), [state.causalGraph, state.statisticalModel, state.propertyTests, state.perspectiveBalance]);
 
   const artifactRef = useRef(artifactData);
   useEffect(() => { artifactRef.current = artifactData; }, [artifactData]);
@@ -141,7 +141,7 @@ export function useWorkspacePersistence() {
   const setCausalGraph = useCallback((v: string | null) => setState((s) => ({ ...s, causalGraph: v })), []);
   const setStatisticalModel = useCallback((v: string | null) => setState((s) => ({ ...s, statisticalModel: v })), []);
   const setPropertyTests = useCallback((v: string | null) => setState((s) => ({ ...s, propertyTests: v })), []);
-  const setDialecticalMap = useCallback((v: string | null) => setState((s) => ({ ...s, dialecticalMap: v })), []);
+  const setPerspectiveBalance = useCallback((v: string | null) => setState((s) => ({ ...s, perspectiveBalance: v })), []);
 
   // Stable return object that destructures the same as before
   return useMemo(() => ({
@@ -167,9 +167,9 @@ export function useWorkspacePersistence() {
     setStatisticalModel,
     propertyTests: state.propertyTests,
     setPropertyTests,
-    dialecticalMap: state.dialecticalMap,
-    setDialecticalMap,
+    perspectiveBalance: state.perspectiveBalance,
+    setPerspectiveBalance,
     restoredDecompState,
     persistDecompState,
-  }), [state, restoredDecompState, persistDecompState, setSourceText, setExtractedFiles, setContextText, setSemiformalText, setLeanCode, setSemiformalDirty, setVerificationStatus, setVerificationErrors, setCausalGraph, setStatisticalModel, setPropertyTests, setDialecticalMap]);
+  }), [state, restoredDecompState, persistDecompState, setSourceText, setExtractedFiles, setContextText, setSemiformalText, setLeanCode, setSemiformalDirty, setVerificationStatus, setVerificationErrors, setCausalGraph, setStatisticalModel, setPropertyTests, setPerspectiveBalance]);
 }

--- a/app/lib/types/artifacts.ts
+++ b/app/lib/types/artifacts.ts
@@ -85,9 +85,9 @@ export type PropertyTestsResponse = {
   };
 };
 
-/** Dialectical Map response shape (003 §3) */
-export type DialecticalMapResponse = {
-  dialecticalMap: {
+/** Balanced Perspectives response shape (003 §3) */
+export type PerspectiveBalanceResponse = {
+  perspectiveBalance: {
     topic: string;
     perspectives: Array<{
       id: string;
@@ -118,7 +118,7 @@ export const ARTIFACT_META: Record<ArtifactType, { label: string; chipLabel: str
   "causal-graph": { label: "Causal Graph", chipLabel: "Causal Graph" },
   "statistical-model": { label: "Statistical Model", chipLabel: "Statistical Model" },
   "property-tests": { label: "Property Tests", chipLabel: "Property Tests" },
-  "dialectical-map": { label: "Dialectical Map", chipLabel: "Dialectical Map" },
+  "perspective-balance": { label: "Balanced Perspectives", chipLabel: "Balanced Perspectives" },
 };
 
 /** Artifact types selectable as chips (lean excluded — it's step 2 of the deductive pipeline) */
@@ -127,7 +127,7 @@ export const SELECTABLE_ARTIFACT_TYPES: ArtifactType[] = [
   "causal-graph",
   "statistical-model",
   "property-tests",
-  "dialectical-map",
+  "perspective-balance",
 ];
 
 /** Maps artifact types to their API route paths */
@@ -135,7 +135,7 @@ export const ARTIFACT_ROUTE: Partial<Record<ArtifactType, string>> = {
   "causal-graph": "/api/formalization/causal-graph",
   "statistical-model": "/api/formalization/statistical-model",
   "property-tests": "/api/formalization/property-tests",
-  "dialectical-map": "/api/formalization/dialectical-map",
+  "perspective-balance": "/api/formalization/perspective-balance",
 };
 
 /** Maps artifact types to their JSON response key (kebab-case -> camelCase) */
@@ -145,5 +145,5 @@ export const ARTIFACT_RESPONSE_KEY: Record<ArtifactType, string> = {
   "causal-graph": "causalGraph",
   "statistical-model": "statisticalModel",
   "property-tests": "propertyTests",
-  "dialectical-map": "dialecticalMap",
+  "perspective-balance": "perspectiveBalance",
 };

--- a/app/lib/types/panels.ts
+++ b/app/lib/types/panels.ts
@@ -7,7 +7,7 @@ export type PanelId =
   | "causal-graph"
   | "statistical-model"
   | "property-tests"
-  | "dialectical-map"
+  | "perspective-balance"
   | "analytics";
 
 export type PanelGroup = "navigation" | "artifacts" | "meta";

--- a/app/lib/types/persistence.ts
+++ b/app/lib/types/persistence.ts
@@ -25,5 +25,5 @@ export type PersistedWorkspace = {
   causalGraph: string | null;
   statisticalModel: string | null;
   propertyTests: string | null;
-  dialecticalMap: string | null;
+  perspectiveBalance: string | null;
 };

--- a/app/lib/types/session.ts
+++ b/app/lib/types/session.ts
@@ -11,7 +11,7 @@ export type ArtifactType =
   | "causal-graph"
   | "statistical-model"
   | "property-tests"
-  | "dialectical-map";
+  | "perspective-balance";
 
 export type ArtifactData = {
   type: ArtifactType;

--- a/app/lib/utils/exportAll.ts
+++ b/app/lib/utils/exportAll.ts
@@ -5,7 +5,7 @@
 
 import JSZip from "jszip";
 import type { PropositionNode } from "@/app/lib/types/decomposition";
-import type { CausalGraphResponse, StatisticalModelResponse, PropertyTestsResponse, DialecticalMapResponse } from "@/app/lib/types/artifacts";
+import type { CausalGraphResponse, StatisticalModelResponse, PropertyTestsResponse, PerspectiveBalanceResponse } from "@/app/lib/types/artifacts";
 import { sanitizeFilename, triggerDownload } from "./export";
 import { getGraphViewportElement, graphToPngBlob } from "./exportGraph";
 
@@ -16,7 +16,7 @@ type ExportAllOptions = {
   causalGraph?: CausalGraphResponse["causalGraph"] | null;
   statisticalModel?: StatisticalModelResponse["statisticalModel"] | null;
   propertyTests?: PropertyTestsResponse["propertyTests"] | null;
-  dialecticalMap?: DialecticalMapResponse["dialecticalMap"] | null;
+  perspectiveBalance?: PerspectiveBalanceResponse["perspectiveBalance"] | null;
 };
 
 export async function exportAllAsZip({
@@ -26,7 +26,7 @@ export async function exportAllAsZip({
   causalGraph,
   statisticalModel,
   propertyTests,
-  dialecticalMap,
+  perspectiveBalance,
 }: ExportAllOptions) {
   const zip = new JSZip();
 
@@ -48,8 +48,8 @@ export async function exportAllAsZip({
   if (propertyTests) {
     zip.file("property-tests.json", JSON.stringify(propertyTests, null, 2));
   }
-  if (dialecticalMap) {
-    zip.file("dialectical-map.json", JSON.stringify(dialecticalMap, null, 2));
+  if (perspectiveBalance) {
+    zip.file("perspective-balance.json", JSON.stringify(perspectiveBalance, null, 2));
   }
 
   // Graph screenshot (best-effort)

--- a/app/lib/utils/workspacePersistence.ts
+++ b/app/lib/utils/workspacePersistence.ts
@@ -59,7 +59,7 @@ export type ArtifactPersistenceData = {
   causalGraph: string | null;
   statisticalModel: string | null;
   propertyTests: string | null;
-  dialecticalMap: string | null;
+  perspectiveBalance: string | null;
 };
 
 export type SaveWorkspaceInput = {
@@ -76,7 +76,7 @@ export type SaveWorkspaceInput = {
 };
 
 export function saveWorkspace(input: SaveWorkspaceInput): boolean {
-  const artifacts = input.artifacts ?? { causalGraph: null, statisticalModel: null, propertyTests: null, dialecticalMap: null };
+  const artifacts = input.artifacts ?? { causalGraph: null, statisticalModel: null, propertyTests: null, perspectiveBalance: null };
   const data: PersistedWorkspace = {
     version: WORKSPACE_VERSION,
     sourceText: input.sourceText,
@@ -94,7 +94,7 @@ export function saveWorkspace(input: SaveWorkspaceInput): boolean {
     causalGraph: artifacts.causalGraph,
     statisticalModel: artifacts.statisticalModel,
     propertyTests: artifacts.propertyTests,
-    dialecticalMap: artifacts.dialecticalMap,
+    perspectiveBalance: artifacts.perspectiveBalance,
   };
 
   try {
@@ -178,7 +178,7 @@ export function loadWorkspace(): PersistedWorkspace | null {
       causalGraph: typeof parsed.causalGraph === "string" ? parsed.causalGraph : null,
       statisticalModel: typeof parsed.statisticalModel === "string" ? parsed.statisticalModel : null,
       propertyTests: typeof parsed.propertyTests === "string" ? parsed.propertyTests : null,
-      dialecticalMap: typeof parsed.dialecticalMap === "string" ? parsed.dialecticalMap : null,
+      perspectiveBalance: typeof parsed.perspectiveBalance === "string" ? parsed.perspectiveBalance : null,
     };
   } catch {
     return null;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ import LeanPanel from "@/app/components/panels/LeanPanel";
 import CausalGraphPanel from "@/app/components/panels/CausalGraphPanel";
 import StatisticalModelPanel from "@/app/components/panels/StatisticalModelPanel";
 import PropertyTestsPanel from "@/app/components/panels/PropertyTestsPanel";
-import DialecticalMapPanel from "@/app/components/panels/DialecticalMapPanel";
+import PerspectiveBalancePanel from "@/app/components/panels/PerspectiveBalancePanel";
 import GraphPanel from "@/app/components/panels/GraphPanel";
 import NodeDetailPanel from "@/app/components/panels/NodeDetailPanel";
 import AnalyticsPanel from "@/app/components/panels/AnalyticsPanel";
@@ -47,7 +47,7 @@ export default function Home() {
     causalGraph: persistedCausalGraph, setCausalGraph: setPersistedCausalGraph,
     statisticalModel: persistedStatisticalModel, setStatisticalModel: setPersistedStatisticalModel,
     propertyTests: persistedPropertyTests, setPropertyTests: setPersistedPropertyTests,
-    dialecticalMap: persistedDialecticalMap, setDialecticalMap: setPersistedDialecticalMap,
+    perspectiveBalance: persistedPerspectiveBalance, setPerspectiveBalance: setPersistedPerspectiveBalance,
   } = useWorkspacePersistence();
 
   // --- Artifact data (persisted as JSON strings, parsed for display) ---
@@ -61,7 +61,7 @@ export default function Home() {
   const causalGraph = useMemo(() => parseJsonOrNull<import("@/app/lib/types/artifacts").CausalGraphResponse["causalGraph"]>(persistedCausalGraph), [persistedCausalGraph, parseJsonOrNull]);
   const statisticalModel = useMemo(() => parseJsonOrNull<import("@/app/lib/types/artifacts").StatisticalModelResponse["statisticalModel"]>(persistedStatisticalModel), [persistedStatisticalModel, parseJsonOrNull]);
   const propertyTests = useMemo(() => parseJsonOrNull<import("@/app/lib/types/artifacts").PropertyTestsResponse["propertyTests"]>(persistedPropertyTests), [persistedPropertyTests, parseJsonOrNull]);
-  const dialecticalMap = useMemo(() => parseJsonOrNull<import("@/app/lib/types/artifacts").DialecticalMapResponse["dialecticalMap"]>(persistedDialecticalMap), [persistedDialecticalMap, parseJsonOrNull]);
+  const perspectiveBalance = useMemo(() => parseJsonOrNull<import("@/app/lib/types/artifacts").PerspectiveBalanceResponse["perspectiveBalance"]>(persistedPerspectiveBalance), [persistedPerspectiveBalance, parseJsonOrNull]);
 
   // --- Artifact type selection + parallel generation ---
   const [selectedArtifactTypes, setSelectedArtifactTypes] = useState<ArtifactType[]>([]);
@@ -79,7 +79,7 @@ export default function Home() {
   const causalGraphLoading = artifactLoadingState["causal-graph"] === "generating";
   const statisticalModelLoading = artifactLoadingState["statistical-model"] === "generating";
   const propertyTestsLoading = artifactLoadingState["property-tests"] === "generating";
-  const dialecticalMapLoading = artifactLoadingState["dialectical-map"] === "generating";
+  const perspectiveBalanceLoading = artifactLoadingState["perspective-balance"] === "generating";
 
   // --- Decomposition state ---
   const { state: decomp, selectedNode, extractPropositions, selectNode, updateNode, resetState: resetDecomp } = useDecomposition();
@@ -133,10 +133,10 @@ export default function Home() {
         case "causal-graph": setPersistedCausalGraph(artifact.content); break;
         case "statistical-model": setPersistedStatisticalModel(artifact.content); break;
         case "property-tests": setPersistedPropertyTests(artifact.content); break;
-        case "dialectical-map": setPersistedDialecticalMap(artifact.content); break;
+        case "perspective-balance": setPersistedPerspectiveBalance(artifact.content); break;
       }
     }
-  }, [selectNode, updateNode, setSemiformalText, setLeanCode, setVerificationStatus, setVerificationErrors, setSemiformalDirty, setPersistedCausalGraph, setPersistedStatisticalModel, setPersistedPropertyTests, setPersistedDialecticalMap]);
+  }, [selectNode, updateNode, setSemiformalText, setLeanCode, setVerificationStatus, setVerificationErrors, setSemiformalDirty, setPersistedCausalGraph, setPersistedStatisticalModel, setPersistedPropertyTests, setPersistedPerspectiveBalance]);
 
   const {
     activeSession,
@@ -191,10 +191,10 @@ export default function Home() {
     if (results["property-tests"]) {
       setPersistedPropertyTests(JSON.stringify(results["property-tests"]));
     }
-    if (results["dialectical-map"]) {
-      setPersistedDialecticalMap(JSON.stringify(results["dialectical-map"]));
+    if (results["perspective-balance"]) {
+      setPersistedPerspectiveBalance(JSON.stringify(results["perspective-balance"]));
     }
-  }, [updateSessionArtifact, updateNode, decomp.nodes, setPersistedCausalGraph, setPersistedStatisticalModel, setPersistedPropertyTests, setPersistedDialecticalMap]);
+  }, [updateSessionArtifact, updateNode, decomp.nodes, setPersistedCausalGraph, setPersistedStatisticalModel, setPersistedPropertyTests, setPersistedPerspectiveBalance]);
 
   // --- Combined paper text for single-proof formalization ---
   const combinedPaperText = useMemo(() => {
@@ -440,14 +440,14 @@ export default function Home() {
     statisticalModelLoading,
     hasPropertyTests: propertyTests !== null,
     propertyTestsLoading,
-    hasDialecticalMap: dialecticalMap !== null,
-    dialecticalMapLoading,
+    hasPerspectiveBalance: perspectiveBalance !== null,
+    perspectiveBalanceLoading,
   });
 
   // --- Export All handler ---
   const hasExportableContent = Boolean(
     semiformalText.trim() || leanCode.trim() || decomp.nodes.length > 0
-    || causalGraph || statisticalModel || propertyTests || dialecticalMap
+    || causalGraph || statisticalModel || propertyTests || perspectiveBalance
   );
 
   const handleExportAll = useCallback(async () => {
@@ -460,9 +460,9 @@ export default function Home() {
       causalGraph,
       statisticalModel,
       propertyTests,
-      dialecticalMap,
+      perspectiveBalance,
     });
-  }, [semiformalText, leanCode, decomp.nodes, causalGraph, statisticalModel, propertyTests, dialecticalMap]);
+  }, [semiformalText, leanCode, decomp.nodes, causalGraph, statisticalModel, propertyTests, perspectiveBalance]);
 
   // --- Panel render function (only creates JSX for the active panel) ---
   const renderPanel = useCallback((panelId: PanelId): React.ReactNode => {
@@ -572,11 +572,11 @@ export default function Home() {
             loading={propertyTestsLoading}
           />
         );
-      case "dialectical-map":
+      case "perspective-balance":
         return (
-          <DialecticalMapPanel
-            dialecticalMap={dialecticalMap}
-            loading={dialecticalMapLoading}
+          <PerspectiveBalancePanel
+            perspectiveBalance={perspectiveBalance}
+            loading={perspectiveBalanceLoading}
           />
         );
       case "analytics":
@@ -599,7 +599,7 @@ export default function Home() {
     causalGraph, causalGraphLoading,
     statisticalModel, statisticalModelLoading,
     propertyTests, propertyTestsLoading,
-    dialecticalMap, dialecticalMapLoading,
+    perspectiveBalance, perspectiveBalanceLoading,
     analyticsEntries, analyticsSummary, clearAnalytics,
   ]);
 

--- a/docs/decisions/001-formal-artifact-types.md
+++ b/docs/decisions/001-formal-artifact-types.md
@@ -4,7 +4,7 @@
 
 **Status:** Accepted
 
-**Context:** The Metaformalism Copilot currently produces two artifact types from user input: semiformal proofs (structured mathematical prose) and Lean4 code (machine-verified deductive proofs). Many insights and arguments that users want to formalize are not well-served by Lean — they may be causal, statistical, dialectical, or constructive in nature. The tool needs additional formalization modes to fulfill its "generalization via inclusion" philosophy.
+**Context:** The Metaformalism Copilot currently produces two artifact types from user input: semiformal proofs (structured mathematical prose) and Lean4 code (machine-verified deductive proofs). Many insights and arguments that users want to formalize are not well-served by Lean — they may be causal, statistical, perspectival, or constructive in nature. The tool needs additional formalization modes to fulfill its "generalization via inclusion" philosophy.
 
 ## Decision
 
@@ -36,7 +36,7 @@ Expand the formalization pipeline to support four new artifact types alongside t
 
 **Best for:** Arguments with constructive content — "it's possible to build X satisfying Y" — where the claim can be checked against concrete examples. Planning requirements before developing software.
 
-### 4. Dialectical Map
+### 4. Balanced Perspectives
 
 **What it is:** A structured decomposition of an argument into multiple coherent perspectives (strains of argument), each articulated in its own direction, followed by a synthesis that identifies an equilibrium between those perspectives.
 
@@ -54,7 +54,7 @@ These four types plus the existing deductive (Lean) path span five dimensions of
 | Causal | Causal graph | "What causes what?" |
 | Statistical | Statistical model | "What does the data say?" |
 | Constructive | Property test suite | "What must hold if you build it?" |
-| Dialectical | Dialectical map | "What are the tensions and how do they resolve?" |
+| Perspectival | Perspectival map | "What are the tensions and how do they resolve?" |
 
 Each artifact type should:
 - Be generatable from the same source material the tool already ingests
@@ -68,16 +68,16 @@ Each artifact type should:
 A divergent design process generated 15 candidate artifact types. After matching against constraints (LLM-producible, panel-friendly, editable, useful without Lean, aids thinking), five were discarded for being too similar to existing artifacts (literate docs, multi-prover), too niche (TLA+/Alloy), or not addressing the problem (do nothing). The remaining candidates were consolidated around the four dimensions above, informed by both AI-generated options and the project maintainer's use cases.
 
 Notable alternatives that were folded into the final four:
-- **Argument maps (Toulmin structure)** — absorbed into Causal Graph and Dialectical Map
+- **Argument maps (Toulmin structure)** — absorbed into Causal Graph and Balanced Perspectives
 - **Bayesian/probabilistic models** — absorbed into Causal Graph (weights) and Statistical Model (distributions)
-- **Critique scaffolds** — absorbed into Dialectical Map (the adversarial perspective becomes one strand of the dialectic)
+- **Critique scaffolds** — absorbed into Balanced Perspectives (the adversarial perspective becomes one strand of the balanced perspective analysis)
 - **Executable algorithms** — reframed as Property Test Suites (specifications over implementations)
 - **Diagrams-as-code** — a presentation concern applicable to multiple artifact types, not a distinct formalization dimension
 
 ## Consequences
 
 **Makes easier:**
-- Formalizing non-mathematical arguments (causal, empirical, dialectical)
+- Formalizing non-mathematical arguments (causal, empirical, perspectival)
 - Getting value from the tool even when Lean verification is infeasible
 - Producing multiple complementary representations of the same idea
 - Generating precise specifications useful as input to other tools

--- a/docs/decisions/002-multi-artifact-ui-layout.md
+++ b/docs/decisions/002-multi-artifact-ui-layout.md
@@ -4,7 +4,7 @@
 
 **Status:** Accepted
 
-**Context:** Decision [001](001-formal-artifact-types.md) introduced four new artifact types (Causal Graph, Statistical Model, Property Test Suite, Dialectical Map) alongside the existing Semiformal + Lean path. The current UI is structured around a single formalization pipeline: source input → context → "Formalise" → semiformal proof → Lean code. The workspace needs to accommodate multiple artifact types without overwhelming the user or breaking the existing flow.
+**Context:** Decision [001](001-formal-artifact-types.md) introduced four new artifact types (Causal Graph, Statistical Model, Property Test Suite, Balanced Perspectives) alongside the existing Semiformal + Lean path. The current UI is structured around a single formalization pipeline: source input → context → "Formalise" → semiformal proof → Lean code. The workspace needs to accommodate multiple artifact types without overwhelming the user or breaking the existing flow.
 
 **Companion decision:** [003](003-artifact-generation-api.md) defines the backend API contracts, session model changes, and data model evolution that support this UI design. Questions about request/response shapes, parallel generation, per-node context storage, and the deductive two-step pipeline are resolved there.
 
@@ -19,12 +19,12 @@ Replace the single "Formalise" button with an **artifact type selector** — a r
 The chips are:
 
 ```
-[Deductive (Lean)] [Causal Graph] [Statistical Model] [Property Tests] [Dialectical Map]
+[Deductive (Lean)] [Causal Graph] [Statistical Model] [Property Tests] [Balanced Perspectives]
 ```
 
 Multiple chips can be active simultaneously. "Deductive (Lean)" is the existing semiformal-then-Lean pipeline, presented as one of five peer options rather than the default.
 
-**Why chips over a dropdown:** Chips make the full set of options visible at a glance. This is critical for discoverability — users who don't know about causal graphs or dialectical maps will see them as options and can learn what they are. A dropdown hides these behind an extra click.
+**Why chips over a dropdown:** Chips make the full set of options visible at a glance. This is critical for discoverability — users who don't know about causal graphs or balanced perspectives will see them as options and can learn what they are. A dropdown hides these behind an extra click.
 
 The chip selector appears in two places:
 - **InputPanel** — for "formalise directly" (whole-source) generation
@@ -85,7 +85,7 @@ The rail gains a visual section separator between input/navigation panels and ar
 [Causal Graph]            ← hidden until generated
 [Statistical Model]       ← hidden until generated
 [Property Tests]          ← hidden until generated
-[Dialectical Map]         ← hidden until generated
+[Balanced Perspectives]         ← hidden until generated
 ─── ───
 [LLM Usage]               ← always visible
 ```
@@ -108,7 +108,7 @@ export type PanelId =
   | "causal-graph"       // new
   | "statistical-model"  // new
   | "property-tests"     // new
-  | "dialectical-map"    // new
+  | "perspective-balance"    // new
   | "analytics";
 ```
 

--- a/docs/decisions/003-artifact-generation-api.md
+++ b/docs/decisions/003-artifact-generation-api.md
@@ -8,7 +8,7 @@
 
 The existing backend follows a clear pattern: each API route is a Next.js route handler at `app/api/<domain>/<action>/route.ts` that calls `callLlm()` with a system prompt and user content, returning a domain-specific response shape. The existing formalization pipeline is sequential: `formalization/semiformal` produces prose, `formalization/lean` converts that prose to code, and `verification/lean` checks the code against a verifier service. Each step depends on the previous step's output.
 
-The four new artifact types (causal graph, statistical model, property test suite, dialectical map) are fundamentally different: they are **independent of each other and independent of the existing deductive pipeline**. A causal graph is not derived from a semiformal proof. This independence is the key architectural fact driving the API design.
+The four new artifact types (causal graph, statistical model, property test suite, balanced perspectives) are fundamentally different: they are **independent of each other and independent of the existing deductive pipeline**. A causal graph is not derived from a semiformal proof. This independence is the key architectural fact driving the API design.
 
 ## Decision
 
@@ -23,7 +23,7 @@ app/api/formalization/
   causal-graph/route.ts      # new
   statistical-model/route.ts # new
   property-tests/route.ts    # new
-  dialectical-map/route.ts   # new
+  perspective-balance/route.ts   # new
 ```
 
 **Why not a single `/formalization/generate` route with a `type` parameter:** Each artifact type has a different system prompt, different response shape, and different post-processing needs. A single route would become a large switch statement. Separate routes follow the existing pattern and keep each route handler focused.
@@ -128,11 +128,11 @@ type PropertyTestsResponse = {
 
 Property tests return pseudocode specifications, not runnable code in a specific language. This aligns with 001's principle that the tool produces specifications, not implementations.
 
-#### Dialectical Map
+#### Balanced Perspectives
 
 ```typescript
-type DialecticalMapResponse = {
-  dialecticalMap: {
+type PerspectiveBalanceResponse = {
+  perspectiveBalance: {
     topic: string;
     perspectives: Array<{
       id: string;
@@ -166,7 +166,7 @@ Deductive:    source + context  ->  semiformal  ->  lean  ->  verify
 Causal:       source + context  ->  causal graph  ->  verify (consistency)
 Statistical:  source + context  ->  statistical model  ->  verify (consistency)
 Constructive: source + context  ->  property tests  ->  verify (structural)
-Dialectical:  source + context  ->  dialectical map  ->  verify (coverage)
+Perspectival:  source + context  ->  balanced perspectives  ->  verify (coverage)
 ```
 
 This means the frontend can fire all selected artifact generation calls **in parallel**. There is no dependency between artifact types. The only sequential dependency that exists is within the deductive pipeline (semiformal must complete before Lean generation).
@@ -193,7 +193,7 @@ app/api/verification/
   causal-consistency/route.ts    # future — LLM-based consistency check
   statistical-consistency/route.ts # future — LLM-based assumption check
   property-structural/route.ts   # future — structural completeness check
-  dialectical-coverage/route.ts  # future — LLM-based coverage check
+  perspective-coverage/route.ts  # future — LLM-based coverage check
 ```
 
 All four new verification strategies are **LLM-based** (unlike Lean verification which uses an external tool). This means they can follow the same `callLlm()` pattern: send the artifact as user content with a verification-focused system prompt, receive a structured assessment.
@@ -223,7 +223,7 @@ export type ArtifactType =
   | "causal-graph"
   | "statistical-model"
   | "property-tests"
-  | "dialectical-map";
+  | "perspective-balance";
 
 export type ArtifactData = {
   type: ArtifactType;

--- a/docs/decisions/004-generalized-decomposition.md
+++ b/docs/decisions/004-generalized-decomposition.md
@@ -55,7 +55,7 @@ The richer taxonomy enables downstream hints about which artifact types suit eac
 | Node kinds | Natural artifact affinity |
 |------------|--------------------------|
 | definition, lemma, theorem, proposition, corollary, axiom | Deductive (Lean) |
-| claim, evidence, assumption | Dialectical Map, Property Tests |
+| claim, evidence, assumption | Balanced Perspectives, Property Tests |
 | claim + evidence with causal language | Causal Graph |
 | methodology, observation with quantitative content | Statistical Model |
 

--- a/docs/plans/multi-artifact-implementation.md
+++ b/docs/plans/multi-artifact-implementation.md
@@ -7,7 +7,7 @@ Implements decisions [002](../decisions/002-multi-artifact-ui-layout.md) (UI lay
 The type infrastructure is already in place:
 - `ArtifactType` includes all six types (`session.ts`)
 - `ArtifactData`, `NodeArtifact`, `ArtifactGenerationRequest`, `ArtifactVerificationResponse` defined (`session.ts`, `decomposition.ts`, `artifacts.ts`)
-- `PanelId` includes `statistical-model`, `property-tests`, `dialectical-map` (`panels.ts`)
+- `PanelId` includes `statistical-model`, `property-tests`, `perspective-balance` (`panels.ts`)
 - `PropositionNode` has `context`, `selectedArtifactTypes`, `artifacts` fields (declared, unused)
 - `FormalizationSession` has `artifacts: ArtifactData[]` (declared, always `[]`)
 - Causal graph: route + panel + panel definition all working
@@ -45,7 +45,7 @@ This avoids duplicating ~60 lines of error handling and message building across 
 
 **Edit:** `app/lib/types/artifacts.ts`
 
-Add `StatisticalModelResponse`, `PropertyTestsResponse`, `DialecticalMapResponse` (shapes from 003 §3). Add entries to `ARTIFACT_ROUTE` map.
+Add `StatisticalModelResponse`, `PropertyTestsResponse`, `PerspectiveBalanceResponse` (shapes from 003 §3). Add entries to `ARTIFACT_ROUTE` map.
 
 ### 1c. `app/api/formalization/statistical-model/route.ts`
 
@@ -59,10 +59,10 @@ Add `StatisticalModelResponse`, `PropertyTestsResponse`, `DialecticalMapResponse
 - Response key: `propertyTests`
 - Mock: 1 property with pseudocode, 1 data generator, summary
 
-### 1e. `app/api/formalization/dialectical-map/route.ts`
+### 1e. `app/api/formalization/perspective-balance/route.ts`
 
-- System prompt: dialectical analyst
-- Response key: `dialecticalMap`
+- System prompt: perspective balance analyst
+- Response key: `perspectiveBalance`
 - Mock: 2 perspectives, 1 tension, synthesis, summary
 
 ### 1f. Migrate semiformal route to uniform request shape
@@ -101,12 +101,12 @@ export const ARTIFACT_META: Record<ArtifactType, { label: string; chipLabel: str
   "causal-graph": { label: "Causal Graph", chipLabel: "Causal Graph" },
   "statistical-model": { label: "Statistical Model", chipLabel: "Statistical Model" },
   "property-tests": { label: "Property Tests", chipLabel: "Property Tests" },
-  "dialectical-map": { label: "Dialectical Map", chipLabel: "Dialectical Map" },
+  "perspective-balance": { label: "Balanced Perspectives", chipLabel: "Balanced Perspectives" },
 };
 
 // Selectable as chips (lean excluded — it's step 2 of the deductive pipeline)
 export const SELECTABLE_ARTIFACT_TYPES: ArtifactType[] = [
-  "semiformal", "causal-graph", "statistical-model", "property-tests", "dialectical-map",
+  "semiformal", "causal-graph", "statistical-model", "property-tests", "perspective-balance",
 ];
 ```
 
@@ -148,7 +148,7 @@ Props:
 
 **Edit:** `app/components/ui/icons/PanelIcons.tsx`
 
-Add `StatisticalModelIcon`, `PropertyTestsIcon`, `DialecticalMapIcon`. Simple SVG icons following the existing icon pattern (16x16 or 20x20, stroke-based).
+Add `StatisticalModelIcon`, `PropertyTestsIcon`, `PerspectiveBalanceIcon`. Simple SVG icons following the existing icon pattern (16x16 or 20x20, stroke-based).
 
 ### 3b. `StatisticalModelPanel`
 
@@ -168,11 +168,11 @@ Props: `{ propertyTests: PropertyTestsResponse["propertyTests"] | null; loading:
 
 Renders: summary, properties list (name, description, preconditions, postcondition, pseudocode in monospace block), data generators list.
 
-### 3d. `DialecticalMapPanel`
+### 3d. `PerspectiveBalancePanel`
 
-**New file:** `app/components/panels/DialecticalMapPanel.tsx`
+**New file:** `app/components/panels/PerspectiveBalancePanel.tsx`
 
-Props: `{ dialecticalMap: DialecticalMapResponse["dialecticalMap"] | null; loading: boolean }`
+Props: `{ perspectiveBalance: PerspectiveBalanceResponse["perspectiveBalance"] | null; loading: boolean }`
 
 Renders: topic heading, perspectives (label, core claim, supporting arguments, vulnerabilities), tensions between perspectives, synthesis (equilibrium + how each perspective is addressed).
 
@@ -191,7 +191,7 @@ Renders: topic heading, perspectives (label, core claim, supporting arguments, v
 
 **Edit:** `app/hooks/usePanelDefinitions.tsx`
 
-Add three new `PanelDef` entries for `statistical-model`, `property-tests`, `dialectical-map` — each with `hidden: true` until data exists. Add input props: `hasStatisticalModel`, `hasPropertyTests`, `hasDialecticalMap`, plus loading booleans.
+Add three new `PanelDef` entries for `statistical-model`, `property-tests`, `perspective-balance` — each with `hidden: true` until data exists. Add input props: `hasStatisticalModel`, `hasPropertyTests`, `hasPerspectiveBalance`, plus loading booleans.
 
 ### 4b. IconRail section separator
 
@@ -209,17 +209,17 @@ Add state:
 ```typescript
 const [statisticalModel, setStatisticalModel] = useState(null);
 const [propertyTests, setPropertyTests] = useState(null);
-const [dialecticalMap, setDialecticalMap] = useState(null);
+const [perspectiveBalance, setPerspectiveBalance] = useState(null);
 const [statisticalModelLoading, setStatisticalModelLoading] = useState(false);
 const [propertyTestsLoading, setPropertyTestsLoading] = useState(false);
-const [dialecticalMapLoading, setDialecticalMapLoading] = useState(false);
+const [perspectiveBalanceLoading, setPerspectiveBalanceLoading] = useState(false);
 ```
 
 Add panel content entries:
 ```typescript
 "statistical-model": <StatisticalModelPanel statisticalModel={statisticalModel} loading={statisticalModelLoading} />,
 "property-tests": <PropertyTestsPanel propertyTests={propertyTests} loading={propertyTestsLoading} />,
-"dialectical-map": <DialecticalMapPanel dialecticalMap={dialecticalMap} loading={dialecticalMapLoading} />,
+"perspective-balance": <PerspectiveBalancePanel perspectiveBalance={perspectiveBalance} loading={perspectiveBalanceLoading} />,
 ```
 
 Wire panel definitions with new `has*` / `*Loading` props.
@@ -444,7 +444,7 @@ After `generateArtifacts()` returns results, create `ArtifactData` entries and c
 
 **Edit:** `app/hooks/useWorkspacePersistence.ts`
 
-The persisted workspace shape already includes decomposition state (which includes nodes with artifacts). Ensure the new artifact state variables (statisticalModel, propertyTests, dialecticalMap) are also persisted, or alternatively, derive them from session artifacts on load.
+The persisted workspace shape already includes decomposition state (which includes nodes with artifacts). Ensure the new artifact state variables (statisticalModel, propertyTests, perspectiveBalance) are also persisted, or alternatively, derive them from session artifacts on load.
 
 ### Verification
 

--- a/docs/plans/refactoring-plan.md
+++ b/docs/plans/refactoring-plan.md
@@ -150,7 +150,7 @@ Each item gets its own `refactor/` feature branch off `dev`, merged back into `d
 **Problem:** 6+ panel components duplicate identical header/empty-state/loading-state boilerplate (~20 lines each).
 
 **Files:**
-- `CausalGraphPanel.tsx`, `DialecticalMapPanel.tsx`, `StatisticalModelPanel.tsx`, `PropertyTestsPanel.tsx`, `LeanPanel.tsx`, `SemiformalPanel.tsx`
+- `CausalGraphPanel.tsx`, `PerspectiveBalancePanel.tsx`, `StatisticalModelPanel.tsx`, `PropertyTestsPanel.tsx`, `LeanPanel.tsx`, `SemiformalPanel.tsx`
 
 **Plan:**
 1. Create `<ArtifactPanelShell title loading data emptyMessage>` component


### PR DESCRIPTION
## Summary

- Renames all references to "dialectical map" → "balanced perspectives" across 18 files (closes #51)
- The term "dialectics" carries specific philosophical baggage from Maoism and Methodism; "balanced perspectives" better describes the feature's actual function of mapping and synthesizing multiple viewpoints
- Pure rename — no behavioral changes, no new lint errors introduced

## What changed

| Layer | Old name | New name |
|-------|----------|----------|
| Panel ID / route | `dialectical-map` | `perspective-balance` |
| Type / component | `DialecticalMap*` | `PerspectiveBalance*` |
| State / props | `dialecticalMap` | `perspectiveBalance` |
| Display label | "Dialectical Map" | "Balanced Perspectives" |

**Files touched:** API route, panel component, icon, 4 type files, 3 hooks/utils, page.tsx, 6 docs

## Test plan

- [ ] `npm run lint` passes (same pre-existing warnings as before)
- [ ] App loads, "Balanced Perspectives" chip appears in artifact selector
- [ ] Generating a balanced perspectives artifact routes to `/api/formalization/perspective-balance` and renders in the renamed panel
- [ ] Export All produces `perspective-balance.json` in the zip
- [ ] Existing persisted workspace data with old `dialecticalMap` key gracefully handles the rename (users may need to regenerate this artifact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)