### PR TITLE
feat: formalization type descriptions and browse modal

### DIFF
--- a/app/components/features/artifact-selector/ArtifactChipSelector.tsx
+++ b/app/components/features/artifact-selector/ArtifactChipSelector.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import type { ArtifactType } from "@/app/lib/types/session";
 import { ARTIFACT_META, SELECTABLE_ARTIFACT_TYPES } from "@/app/lib/types/artifacts";
+import ArtifactTypeModal from "./ArtifactTypeModal";
 
 type ArtifactChipSelectorProps = {
   selected: ArtifactType[];
@@ -16,6 +18,8 @@ export default function ArtifactChipSelector({
   loading = {},
   disabled = false,
 }: ArtifactChipSelectorProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+
   function toggle(type: ArtifactType) {
     if (disabled) return;
     if (selected.includes(type)) {
@@ -25,58 +29,95 @@ export default function ArtifactChipSelector({
     }
   }
 
-  return (
-    <div className="flex flex-wrap gap-2">
-      {SELECTABLE_ARTIFACT_TYPES.map((type) => {
-        const isActive = selected.includes(type);
-        const isLoading = loading[type] ?? false;
+  const selectedSelectable = selected.filter((t) =>
+    SELECTABLE_ARTIFACT_TYPES.includes(t)
+  );
 
-        return (
-          <button
-            key={type}
-            type="button"
-            onClick={() => toggle(type)}
-            disabled={disabled}
-            className={`
-              relative inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm
-              transition-colors duration-150 border
-              ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}
-              ${
-                isActive
-                  ? "bg-[var(--ink-black)] text-[var(--ivory-cream)] border-[var(--ink-black)]"
-                  : "bg-transparent text-[var(--ink-black)] border-[var(--border-light)] hover:border-[var(--ink-black)]"
-              }
-            `}
-          >
-            {isLoading && (
-              <span className="absolute inset-0 flex items-center justify-center rounded-full bg-inherit">
-                <svg
-                  className="h-4 w-4 animate-spin"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="3"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                  />
-                </svg>
-              </span>
-            )}
-            <span className={isLoading ? "invisible" : ""}>
-              {ARTIFACT_META[type].chipLabel}
-            </span>
-          </button>
-        );
-      })}
-    </div>
+  return (
+    <>
+      <div className="flex flex-col gap-1.5">
+        <div className="flex flex-wrap gap-2">
+          {SELECTABLE_ARTIFACT_TYPES.map((type) => {
+            const isActive = selected.includes(type);
+            const isLoading = loading[type] ?? false;
+
+            return (
+              <button
+                key={type}
+                type="button"
+                onClick={() => toggle(type)}
+                disabled={disabled}
+                className={`
+                  relative inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm
+                  transition-colors duration-150 border
+                  ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}
+                  ${
+                    isActive
+                      ? "bg-[var(--ink-black)] text-[var(--ivory-cream)] border-[var(--ink-black)]"
+                      : "bg-transparent text-[var(--ink-black)] border-[var(--border-light)] hover:border-[var(--ink-black)]"
+                  }
+                `}
+              >
+                {isLoading && (
+                  <span className="absolute inset-0 flex items-center justify-center rounded-full bg-inherit">
+                    <svg
+                      className="h-4 w-4 animate-spin"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="3"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                      />
+                    </svg>
+                  </span>
+                )}
+                <span className={isLoading ? "invisible" : ""}>
+                  {ARTIFACT_META[type].chipLabel}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setModalOpen(true)}
+          className="self-start text-xs text-[#6B6560] hover:text-[var(--ink-black)] underline transition-colors cursor-pointer"
+        >
+          Browse types
+        </button>
+
+        {selectedSelectable.length > 0 && (
+          <ul className="flex flex-col gap-0.5 mt-0.5">
+            {selectedSelectable.map((type) => (
+              <li key={type} className="text-xs text-[#6B6560]">
+                <span className="font-medium text-[var(--ink-black)]">
+                  {ARTIFACT_META[type].chipLabel}:
+                </span>{" "}
+                {ARTIFACT_META[type].description}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {modalOpen && (
+        <ArtifactTypeModal
+          selected={selected}
+          onChange={onChange}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
+    </>
   );
 }

--- a/app/components/features/artifact-selector/ArtifactTypeModal.tsx
+++ b/app/components/features/artifact-selector/ArtifactTypeModal.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect } from "react";
+import type { ArtifactType } from "@/app/lib/types/session";
+import { ARTIFACT_META, SELECTABLE_ARTIFACT_TYPES } from "@/app/lib/types/artifacts";
+
+type ArtifactTypeModalProps = {
+  selected: ArtifactType[];
+  onChange: (types: ArtifactType[]) => void;
+  onClose: () => void;
+};
+
+export default function ArtifactTypeModal({
+  selected,
+  onChange,
+  onClose,
+}: ArtifactTypeModalProps) {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  function toggle(type: ArtifactType) {
+    if (selected.includes(type)) {
+      onChange(selected.filter((t) => t !== type));
+    } else {
+      onChange([...selected, type]);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/30"
+      onClick={onClose}
+    >
+      <div
+        className="mx-4 max-w-lg w-full rounded-lg border border-[#DDD9D5] bg-white p-5 shadow-xl"
+        style={{ fontFamily: "var(--font-serif, 'EB Garamond', serif)" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-[var(--ink-black)]">
+            Choose Formalization Types
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-[#6B6560] hover:text-[var(--ink-black)] transition-colors text-xl leading-none px-1"
+            aria-label="Close"
+          >
+            &times;
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          {SELECTABLE_ARTIFACT_TYPES.map((type) => {
+            const meta = ARTIFACT_META[type];
+            const isActive = selected.includes(type);
+
+            return (
+              <button
+                key={type}
+                type="button"
+                onClick={() => toggle(type)}
+                className={`
+                  text-left rounded-lg border p-3 transition-colors duration-150 cursor-pointer
+                  ${
+                    isActive
+                      ? "border-[var(--ink-black)] bg-[var(--ink-black)]/5"
+                      : "border-[#DDD9D5] hover:border-[var(--ink-black)]"
+                  }
+                `}
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <span
+                    className={`
+                      inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium
+                      ${
+                        isActive
+                          ? "bg-[var(--ink-black)] text-[var(--ivory-cream)]"
+                          : "bg-[#F5F1ED] text-[var(--ink-black)]"
+                      }
+                    `}
+                  >
+                    {meta.chipLabel}
+                  </span>
+                </div>
+                <p className="text-sm text-[var(--ink-black)] mb-1">
+                  {meta.description}
+                </p>
+                <p className="text-xs text-[#6B6560]">
+                  <span className="font-medium">When to use:</span> {meta.whenToUse}
+                </p>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/lib/types/artifacts.ts
+++ b/app/lib/types/artifacts.ts
@@ -112,13 +112,48 @@ export type DialecticalMapResponse = {
 };
 
 /** Display metadata for each artifact type */
-export const ARTIFACT_META: Record<ArtifactType, { label: string; chipLabel: string }> = {
-  semiformal: { label: "Semiformal Proof", chipLabel: "Deductive (Lean)" },
-  lean: { label: "Lean4 Code", chipLabel: "Lean4 Code" },
-  "causal-graph": { label: "Causal Graph", chipLabel: "Causal Graph" },
-  "statistical-model": { label: "Statistical Model", chipLabel: "Statistical Model" },
-  "property-tests": { label: "Property Tests", chipLabel: "Property Tests" },
-  "dialectical-map": { label: "Dialectical Map", chipLabel: "Dialectical Map" },
+export const ARTIFACT_META: Record<ArtifactType, {
+  label: string;
+  chipLabel: string;
+  description: string;
+  whenToUse: string;
+}> = {
+  semiformal: {
+    label: "Semiformal Proof",
+    chipLabel: "Deductive (Lean)",
+    description: "Structured deductive argument with mathematical notation, logical steps, and a machine-verifiable Lean 4 proof.",
+    whenToUse: "Claims that can be stated as precise propositions needing formal verification.",
+  },
+  lean: {
+    label: "Lean4 Code",
+    chipLabel: "Lean4 Code",
+    description: "Raw Lean 4 theorem prover code.",
+    whenToUse: "Generated automatically as step 2 of the deductive pipeline.",
+  },
+  "causal-graph": {
+    label: "Causal Graph",
+    chipLabel: "Causal Graph",
+    description: "Directed graph of variables, causal relationships, confounders, and mechanisms.",
+    whenToUse: "Reasoning about cause-and-effect, interventions, or counterfactual questions.",
+  },
+  "statistical-model": {
+    label: "Statistical Model",
+    chipLabel: "Statistical Model",
+    description: "Variables with roles, testable hypotheses with null hypotheses, and suggested statistical tests.",
+    whenToUse: "Claims involving quantities, correlations, or empirical evidence testable with data.",
+  },
+  "property-tests": {
+    label: "Property Tests",
+    chipLabel: "Property Tests",
+    description: "Invariants, preconditions, postconditions, and data generators as executable test specs.",
+    whenToUse: "Rules that should always hold, especially for computational or algorithmic claims.",
+  },
+  "dialectical-map": {
+    label: "Dialectical Map",
+    chipLabel: "Dialectical Map",
+    description: "Map of distinct viewpoints, tensions between them, and a proposed synthesis.",
+    whenToUse: "Topics with multiple legitimate viewpoints where you want the full argumentative terrain.",
+  },
 };
 
 /** Artifact types selectable as chips (lean excluded — it's step 2 of the deductive pipeline) */


### PR DESCRIPTION
## Summary
- Add `description` and `whenToUse` fields to `ARTIFACT_META` for all 6 artifact types
- New `ArtifactTypeModal` component for browsing all formalization types with full descriptions and toggle selection
- Updated `ArtifactChipSelector` with a "Browse types" link and inline descriptions for selected types

Closes #50

## Test plan
- [x] Chips still toggle selection as before
- [x] "Browse types" link appears below the chip row
- [x] Clicking "Browse types" opens the modal with all 5 selectable types
- [x] Modal cards show chipLabel, description, and "when to use" text
- [x] Clicking a card toggles its selection (synced with chip state)
- [x] Modal closes on backdrop click, close button, or Escape key
- [x] Selected types show inline descriptions below the chips
- [x] `npm run lint` passes (no new warnings)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)