### PR TITLE
feat: improve UI element visibility (Phase 1 UXR fixes)

### DIFF
--- a/app/components/features/artifact-selector/ArtifactChipSelector.tsx
+++ b/app/components/features/artifact-selector/ArtifactChipSelector.tsx
@@ -92,23 +92,24 @@ export default function ArtifactChipSelector({
         <button
           type="button"
           onClick={() => setModalOpen(true)}
-          className="self-start text-xs text-[#6B6560] hover:text-[var(--ink-black)] underline transition-colors cursor-pointer"
+          className="self-start text-sm text-[var(--ink-black)] hover:text-[var(--ink-black)] underline decoration-[#9A9590] underline-offset-2 transition-colors cursor-pointer font-medium"
         >
-          Browse types
+          Browse types &rarr;
         </button>
 
-        {selectedSelectable.length > 0 && (
-          <ul className="flex flex-col gap-0.5 mt-0.5">
-            {selectedSelectable.map((type) => (
-              <li key={type} className="text-xs text-[#6B6560]">
-                <span className="font-medium text-[var(--ink-black)]">
-                  {ARTIFACT_META[type].chipLabel}:
-                </span>{" "}
-                {ARTIFACT_META[type].description}
-              </li>
-            ))}
-          </ul>
-        )}
+        <ul className="flex flex-col gap-0.5 mt-0.5">
+          {(selectedSelectable.length > 0
+            ? selectedSelectable
+            : SELECTABLE_ARTIFACT_TYPES
+          ).map((type) => (
+            <li key={type} className="text-xs text-[#4A4540]">
+              <span className="font-medium text-[var(--ink-black)]">
+                {ARTIFACT_META[type].chipLabel}:
+              </span>{" "}
+              {ARTIFACT_META[type].description}
+            </li>
+          ))}
+        </ul>
       </div>
 
       {modalOpen && (

--- a/app/components/features/context-input/ContextInput.tsx
+++ b/app/components/features/context-input/ContextInput.tsx
@@ -66,7 +66,7 @@ export default function ContextInput({ value, onChange, onFormalise, loading, wa
     <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
       {/* Scrollable content */}
       <div className="flex flex-1 min-h-0 flex-col gap-3 overflow-auto p-6">
-        <p className="text-sm text-[#6B6560]">
+        <p className="text-sm text-[#4A4540]">
           Describe the theoretical direction, domain, or framework for formalizing your insight
         </p>
         <textarea

--- a/app/components/features/formalization-controls/FormalizationControls.tsx
+++ b/app/components/features/formalization-controls/FormalizationControls.tsx
@@ -50,7 +50,7 @@ export default function FormalizationControls({
 
         {/* Artifact type chips */}
         <div>
-          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#4A4540]">
             Artifact Types
           </h3>
           <ArtifactChipSelector
@@ -68,7 +68,7 @@ export default function FormalizationControls({
           type="button"
           onClick={onGenerate}
           disabled={loading || selectedArtifactTypes.length === 0}
-          className="w-full rounded-full bg-[var(--ink-black)] px-6 py-2.5 text-sm font-medium text-white shadow-md transition-shadow duration-200 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[var(--ink-black)] focus:ring-offset-2 focus:ring-offset-[var(--ivory-cream)] disabled:opacity-50"
+          className="w-full rounded-full bg-[var(--ink-black)] px-6 py-3 text-base font-semibold text-white shadow-md transition-shadow duration-200 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[var(--ink-black)] focus:ring-offset-2 focus:ring-offset-[var(--ivory-cream)] disabled:opacity-50"
         >
           {buttonLabel}
         </button>

--- a/app/components/features/output-editing/EditableOutput.tsx
+++ b/app/components/features/output-editing/EditableOutput.tsx
@@ -122,7 +122,7 @@ export default function EditableOutput({ value, onChange, onInlineEdit, renderMo
       {(value || renderMode === "raw") && (
         <button
           onClick={onToggleEdit}
-          className="absolute right-4 top-4 z-30 rounded-md border border-[#DDD9D5] bg-[var(--ivory-cream)] px-3 py-1 text-xs text-[#6B6560] shadow-sm transition-shadow hover:shadow-md hover:text-[var(--ink-black)] focus:outline-none focus:ring-1 focus:ring-[var(--ink-black)]"
+          className="absolute right-4 top-4 z-30 rounded-md border border-[var(--ink-black)] bg-[var(--ivory-cream)] px-3 py-1.5 text-xs font-medium text-[var(--ink-black)] shadow-sm transition-shadow hover:bg-[var(--ink-black)] hover:text-white hover:shadow-md focus:outline-none focus:ring-1 focus:ring-[var(--ink-black)]"
           aria-label={renderMode === "rendered" ? "Edit raw text" : "Show rendered view"}
         >
           {renderMode === "rendered" ? "Edit" : "Done editing"}

--- a/app/components/features/source-input/TextInput.test.tsx
+++ b/app/components/features/source-input/TextInput.test.tsx
@@ -11,7 +11,7 @@ describe('TextInput', () => {
 
   it('shows placeholder text', () => {
     render(<TextInput value="" onChange={() => {}} />)
-    expect(screen.getByPlaceholderText('Paste or type your source material here...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('e.g., a paragraph from a paper, a rough argument, or a hypothesis you want to make rigorous...')).toBeInTheDocument()
   })
 
   it('calls onChange when user types', async () => {

--- a/app/components/features/source-input/TextInput.tsx
+++ b/app/components/features/source-input/TextInput.tsx
@@ -7,12 +7,15 @@ type TextInputProps = {
 
 export default function TextInput({ value, onChange }: TextInputProps) {
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col gap-1">
+      <p className="text-sm text-[#4A4540]">
+        Paste the argument, claim, or insight you want to formalize
+      </p>
       <textarea
         id="text-input"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Paste or type your source material here..."
+        placeholder="e.g., a paragraph from a paper, a rough argument, or a hypothesis you want to make rigorous..."
         rows={5}
         className="w-full resize-y rounded-md border border-[#DDD9D5] bg-[var(--ivory-cream)] px-4 py-3 text-[var(--ink-black)] placeholder-[#9A9590] shadow-md transition-shadow duration-200 focus:border-[var(--ink-black)] focus:caret-black focus:outline-none focus:ring-1 focus:ring-[var(--ink-black)] focus:shadow-lg"
         style={{ lineHeight: 1.7, caretColor: "#000000" }}

--- a/app/components/layout/IconRail.tsx
+++ b/app/components/layout/IconRail.tsx
@@ -95,7 +95,7 @@ export default function IconRail({ panels, activePanelId, onSelectPanel, onExpor
           title={expanded ? undefined : "Export All"}
           className={`
             group flex items-center gap-3 px-3 py-3 text-left transition-colors border-t border-[#DDD9D5]
-            text-[#6B6560] hover:bg-[var(--rail-hover)] hover:text-[var(--ink-black)]
+            text-[var(--ink-black)] hover:bg-[var(--rail-hover)]
             disabled:opacity-40 disabled:pointer-events-none
           `}
         >


### PR DESCRIPTION
## Summary
- Address critical and serious UXR findings from Round 1 testing where all 3 participants struggled with low-contrast text, hidden controls, and unclear input guidance
- Darken helper text color (`#6B6560` → `#4A4540`) across context labels, artifact type headers, and descriptions
- Add descriptive label and improved placeholder to source text input to reduce "blank canvas" anxiety
- Make "Browse types" link more prominent (larger, bolder, arrow indicator) and show artifact type descriptions by default instead of only after selection
- Increase Formalize button size to better differentiate from Decompose
- Add visible border and hover inversion to the Edit toggle button on output panels
- Darken Export All button in sidebar from muted gray to ink-black

## Test plan
- [x] Verify source input panel shows descriptive label above textarea and new placeholder text
- [x] Verify "Browse types" link is visually prominent (not tiny gray text)
- [x] Verify artifact type descriptions display for all types when none are selected, and filter to selected types when some are chosen
- [x] Verify Formalize button appears larger/bolder than Decompose button
- [x] Verify Edit button on output panels has visible border and inverts on hover
- [x] Verify Export All icon in collapsed sidebar is clearly visible (not washed out)
- [x] Run `npm run lint` and `npm run build` — both pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)