### PR TITLE
feat: Zustand workspace store with compatibility shim (Phase 1 foundation)

### DIFF
--- a/app/hooks/useWorkspacePersistence.test.ts
+++ b/app/hooks/useWorkspacePersistence.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useWorkspacePersistence } from "./useWorkspacePersistence";
 import { WORKSPACE_KEY } from "@/app/lib/types/persistence";
+import { useWorkspaceStore } from "@/app/lib/stores/workspaceStore";
+
+const ZUSTAND_KEY = "workspace-zustand-v1";
 
 describe("useWorkspacePersistence", () => {
   beforeEach(() => {
     localStorage.clear();
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
+    // Reset Zustand store to defaults between tests
+    useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
   });
 
   it("starts with default values when localStorage is empty", () => {
@@ -26,59 +26,88 @@ describe("useWorkspacePersistence", () => {
     expect(result.current.restoredDecompState).toBeNull();
   });
 
-  it("restores saved values on mount", () => {
-    localStorage.setItem(WORKSPACE_KEY, JSON.stringify({
-      version: 2,
-      sourceText: "restored source",
-      extractedFiles: [{ name: "f.txt", text: "content" }],
-      contextText: "restored ctx",
-      semiformalText: "restored semi",
-      leanCode: "restored lean",
-      semiformalDirty: true,
-      verificationStatus: "valid",
-      verificationErrors: "some error",
-      decomposition: {
-        nodes: [{ id: "1", label: "T", kind: "theorem", statement: "", proofText: "", dependsOn: [], semiformalProof: "", leanCode: "", verificationStatus: "verified", verificationErrors: "" }],
-        selectedNodeId: "1",
-        paperText: "paper",
+  it("restores saved values on mount via Zustand rehydration", async () => {
+    // Pre-populate Zustand's localStorage key (the format Zustand persist uses)
+    const saved = {
+      state: {
+        sourceText: "restored source",
+        extractedFiles: [{ name: "f.txt", text: "content" }],
+        contextText: "restored ctx",
+        semiformalText: "restored semi",
+        leanCode: "restored lean",
+        semiformalDirty: true,
+        verificationStatus: "valid",
+        verificationErrors: "some error",
+        artifacts: {},
+        decomposition: {
+          nodes: [{ id: "1", label: "T", kind: "theorem", statement: "", proofText: "", dependsOn: [], sourceId: "", sourceLabel: "", semiformalProof: "", leanCode: "", verificationStatus: "verified", verificationErrors: "", context: "", selectedArtifactTypes: [], artifacts: [] }],
+          selectedNodeId: "1",
+          paperText: "paper",
+          sources: [],
+        },
       },
-    }));
+      version: 0,
+    };
+    localStorage.setItem(ZUSTAND_KEY, JSON.stringify(saved));
+
+    // Rehydrate store (simulates what the shim's useEffect does)
+    await useWorkspaceStore.persist.rehydrate();
 
     const { result } = renderHook(() => useWorkspacePersistence());
 
     expect(result.current.sourceText).toBe("restored source");
     expect(result.current.extractedFiles).toEqual([{ name: "f.txt", text: "content" }]);
     expect(result.current.verificationStatus).toBe("valid");
-    expect(result.current.restoredDecompState).not.toBeNull();
-    expect(result.current.restoredDecompState!.nodes).toHaveLength(1);
   });
 
-  it("saves after 500ms debounce", () => {
+  it("migrates workspace-v2 data on rehydrate", async () => {
+    // Pre-populate old workspace-v2 key
+    localStorage.setItem(WORKSPACE_KEY, JSON.stringify({
+      version: 2,
+      sourceText: "migrated source",
+      extractedFiles: [],
+      contextText: "",
+      semiformalText: "migrated proof",
+      leanCode: "",
+      semiformalDirty: false,
+      verificationStatus: "none",
+      verificationErrors: "",
+      decomposition: { nodes: [], selectedNodeId: null, paperText: "", sources: [] },
+      causalGraph: '{"variables":[]}',
+      statisticalModel: null,
+      propertyTests: null,
+      dialecticalMap: null,
+      counterexamples: null,
+    }));
+
+    // Trigger rehydrate — the onRehydrateStorage callback should detect
+    // workspace-v2 and call migrateFromV2
+    await useWorkspaceStore.persist.rehydrate();
+
+    const store = useWorkspaceStore.getState();
+    expect(store.sourceText).toBe("migrated source");
+    expect(store.semiformalText).toBe("migrated proof");
+    expect(store.getArtifactContent("causal-graph")).toBe('{"variables":[]}');
+  });
+
+  it("persist middleware saves to Zustand key on state change", async () => {
+    await useWorkspaceStore.persist.rehydrate();
+
     const { result } = renderHook(() => useWorkspacePersistence());
 
-    act(() => {
-      result.current.setSourceText("a");
-    });
-    act(() => {
-      result.current.setSourceText("ab");
-    });
     act(() => {
       result.current.setSourceText("abc");
     });
 
-    // Before debounce fires, nothing saved
-    expect(localStorage.getItem(WORKSPACE_KEY)).toBeNull();
-
-    // Advance past debounce
-    act(() => {
-      vi.advanceTimersByTime(600);
-    });
-
-    const stored = JSON.parse(localStorage.getItem(WORKSPACE_KEY)!);
-    expect(stored.sourceText).toBe("abc");
+    // Zustand persist writes synchronously on set()
+    const raw = localStorage.getItem(ZUSTAND_KEY);
+    expect(raw).not.toBeNull();
+    const stored = JSON.parse(raw!);
+    expect(stored.state.sourceText).toBe("abc");
   });
 
   it("falls back to defaults on corrupted localStorage", () => {
+    // Corrupted old key shouldn't crash; store stays at defaults
     localStorage.setItem(WORKSPACE_KEY, "corrupted{{{not json");
     const { result } = renderHook(() => useWorkspacePersistence());
     expect(result.current.sourceText).toBe("");

--- a/app/hooks/useWorkspacePersistence.ts
+++ b/app/hooks/useWorkspacePersistence.ts
@@ -1,158 +1,115 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+/**
+ * Compatibility shim: delegates to the Zustand workspace store while
+ * preserving the exact return API that page.tsx and other consumers expect.
+ *
+ * This shim exists during the migration period. Once page.tsx is wired
+ * directly to useWorkspaceStore (PR 2), this file will be deleted.
+ */
+
+import { useEffect, useRef, useCallback, useMemo } from "react";
 import type { PersistedWorkspace, PersistedDecomposition } from "@/app/lib/types/persistence";
-import type { VerificationStatus } from "@/app/lib/types/session";
-import { loadWorkspace, saveWorkspace, type ArtifactPersistenceData, type SaveWorkspaceInput } from "@/app/lib/utils/workspacePersistence";
-
-type WorkspaceState = {
-  sourceText: string;
-  extractedFiles: { name: string; text: string; file?: File }[];
-  contextText: string;
-  semiformalText: string;
-  leanCode: string;
-  semiformalDirty: boolean;
-  verificationStatus: VerificationStatus;
-  verificationErrors: string;
-  // Artifact data (JSON-stringified)
-  causalGraph: string | null;
-  statisticalModel: string | null;
-  propertyTests: string | null;
-  dialecticalMap: string | null;
-  counterexamples: string | null;
-};
-
-const DEFAULT_STATE: WorkspaceState = {
-  sourceText: "",
-  extractedFiles: [],
-  contextText: "",
-  semiformalText: "",
-  leanCode: "",
-  semiformalDirty: false,
-  verificationStatus: "none",
-  verificationErrors: "",
-  causalGraph: null,
-  statisticalModel: null,
-  propertyTests: null,
-  dialecticalMap: null,
-  counterexamples: null,
-};
+import { useWorkspaceStore } from "@/app/lib/stores/workspaceStore";
+import { sanitizeVerificationStatus } from "@/app/lib/utils/workspacePersistence";
 
 export function useWorkspacePersistence() {
-  const [state, setState] = useState<WorkspaceState>(DEFAULT_STATE);
-
-  // Decomposition state tracked via ref (owned by useDecomposition, mirrored here for persistence)
-  const decompRef = useRef<PersistedDecomposition>({
-    nodes: [],
-    selectedNodeId: null,
-    paperText: "",
-    sources: [],
-  });
-
-  // Restored decomposition state — set once on mount, consumed by page.tsx to call resetState
-  const [restoredDecompState, setRestoredDecompState] = useState<PersistedDecomposition | null>(null);
-
-  // --- Hydrate from localStorage on mount ---
-  // This is the standard Next.js pattern: render SSR-safe defaults first, then
-  // hydrate from localStorage in a mount effect to avoid hydration mismatch.
+  // Trigger Zustand rehydrate once on mount (SSR-safe pattern)
+  const hydrated = useRef(false);
   useEffect(() => {
-    const data = loadWorkspace();
-    if (!data) return;
-
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration from external store (localStorage); must run post-mount to avoid SSR mismatch
-    setState({
-      sourceText: data.sourceText,
-      extractedFiles: data.extractedFiles,
-      contextText: data.contextText,
-      semiformalText: data.semiformalText,
-      leanCode: data.leanCode,
-      semiformalDirty: data.semiformalDirty,
-      verificationStatus: data.verificationStatus,
-      verificationErrors: data.verificationErrors,
-      causalGraph: data.causalGraph,
-      statisticalModel: data.statisticalModel,
-      propertyTests: data.propertyTests,
-      dialecticalMap: data.dialecticalMap,
-      counterexamples: data.counterexamples,
-    });
-
-    decompRef.current = data.decomposition;
-    setRestoredDecompState(data.decomposition);
+    if (!hydrated.current) {
+      hydrated.current = true;
+      useWorkspaceStore.persist.rehydrate();
+    }
   }, []);
 
-  // --- Debounced save on change ---
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Keep a ref to current state so scheduleSave always reads fresh data
-  const stateRef = useRef(state);
-  useEffect(() => { stateRef.current = state; }, [state]);
+  // Subscribe to Zustand store fields that the old API exposed
+  const sourceText = useWorkspaceStore((s) => s.sourceText);
+  const extractedFiles = useWorkspaceStore((s) => s.extractedFiles);
+  const contextText = useWorkspaceStore((s) => s.contextText);
+  const semiformalText = useWorkspaceStore((s) => s.semiformalText);
+  const leanCode = useWorkspaceStore((s) => s.leanCode);
+  const semiformalDirty = useWorkspaceStore((s) => s.semiformalDirty);
+  const verificationStatus = useWorkspaceStore((s) => s.verificationStatus);
+  const verificationErrors = useWorkspaceStore((s) => s.verificationErrors);
+  const decomposition = useWorkspaceStore((s) => s.decomposition);
 
-  const artifactData: ArtifactPersistenceData = useMemo(() => ({
-    causalGraph: state.causalGraph,
-    statisticalModel: state.statisticalModel,
-    propertyTests: state.propertyTests,
-    dialecticalMap: state.dialecticalMap,
-    counterexamples: state.counterexamples,
-  }), [state.causalGraph, state.statisticalModel, state.propertyTests, state.dialecticalMap, state.counterexamples]);
+  // Artifact content (read from versioned store, exposed as flat strings)
+  const causalGraph = useWorkspaceStore((s) => s.getArtifactContent("causal-graph"));
+  const statisticalModel = useWorkspaceStore((s) => s.getArtifactContent("statistical-model"));
+  const propertyTests = useWorkspaceStore((s) => s.getArtifactContent("property-tests"));
+  const dialecticalMap = useWorkspaceStore((s) => s.getArtifactContent("dialectical-map"));
+  const counterexamples = useWorkspaceStore((s) => s.getArtifactContent("counterexamples"));
 
-  const artifactRef = useRef(artifactData);
-  useEffect(() => { artifactRef.current = artifactData; }, [artifactData]);
+  // Stable setter references from the store
+  const setSourceText = useWorkspaceStore((s) => s.setSourceText);
+  const setContextText = useWorkspaceStore((s) => s.setContextText);
+  const setSemiformalText = useWorkspaceStore((s) => s.setSemiformalText);
+  const setLeanCode = useWorkspaceStore((s) => s.setLeanCode);
+  const setSemiformalDirty = useWorkspaceStore((s) => s.setSemiformalDirty);
+  const setVerificationStatus = useWorkspaceStore((s) => s.setVerificationStatus);
+  const setVerificationErrors = useWorkspaceStore((s) => s.setVerificationErrors);
 
-  // Stable save scheduler — reads from refs, never changes identity
-  const scheduleSave = useCallback(() => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(() => {
-      const s = stateRef.current;
-      const input: SaveWorkspaceInput = {
-        sourceText: s.sourceText,
-        extractedFiles: s.extractedFiles,
-        contextText: s.contextText,
-        semiformalText: s.semiformalText,
-        leanCode: s.leanCode,
-        semiformalDirty: s.semiformalDirty,
-        verificationStatus: s.verificationStatus,
-        verificationErrors: s.verificationErrors,
-        decomposition: decompRef.current,
-        artifacts: artifactRef.current,
-      };
-      saveWorkspace(input);
-    }, 500);
-  }, []);
+  // extractedFiles setter: the old API accepted { name, text, file? }[] but
+  // File objects can't be serialized. The store only keeps { name, text }.
+  // Callers that pass File objects will have them stripped on persistence.
+  const setExtractedFiles = useCallback(
+    (v: { name: string; text: string; file?: File }[]) => {
+      useWorkspaceStore.getState().setExtractedFiles(
+        v.map(({ name, text }) => ({ name, text })),
+      );
+    },
+    [],
+  );
 
-  useEffect(() => {
-    scheduleSave();
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-    };
-  }, [state, artifactData, scheduleSave]);
+  // Artifact setters: map old flat-string setters to versioned store
+  const setCausalGraph = useCallback(
+    (v: string | null) => {
+      if (v) useWorkspaceStore.getState().setArtifactGenerated("causal-graph", v);
+    },
+    [],
+  );
+  const setStatisticalModel = useCallback(
+    (v: string | null) => {
+      if (v) useWorkspaceStore.getState().setArtifactGenerated("statistical-model", v);
+    },
+    [],
+  );
+  const setPropertyTests = useCallback(
+    (v: string | null) => {
+      if (v) useWorkspaceStore.getState().setArtifactGenerated("property-tests", v);
+    },
+    [],
+  );
+  const setDialecticalMap = useCallback(
+    (v: string | null) => {
+      if (v) useWorkspaceStore.getState().setArtifactGenerated("dialectical-map", v);
+    },
+    [],
+  );
+  const setCounterexamples = useCallback(
+    (v: string | null) => {
+      if (v) useWorkspaceStore.getState().setArtifactGenerated("counterexamples", v);
+    },
+    [],
+  );
 
-  /** Call this whenever decomposition state changes so persistence stays in sync */
-  const persistDecompState = useCallback((decompState: PersistedDecomposition) => {
-    decompRef.current = decompState;
-    scheduleSave();
-  }, [scheduleSave]);
+  // Decomposition persistence: shim calls setDecomposition on the store
+  const persistDecompState = useCallback(
+    (decompState: PersistedDecomposition) => {
+      useWorkspaceStore.getState().setDecomposition(decompState);
+    },
+    [],
+  );
 
-  // --- Individual setters that match the useState API page.tsx expects ---
-  const setSourceText = useCallback((v: string) => setState((s) => ({ ...s, sourceText: v })), []);
-  const setExtractedFiles = useCallback((v: { name: string; text: string; file?: File }[]) => setState((s) => ({ ...s, extractedFiles: v })), []);
-  const setContextText = useCallback((v: string) => setState((s) => ({ ...s, contextText: v })), []);
-  const setSemiformalText = useCallback((v: string | ((prev: string) => string)) =>
-    setState((s) => ({ ...s, semiformalText: typeof v === "function" ? v(s.semiformalText) : v })), []);
-  const setLeanCode = useCallback((v: string | ((prev: string) => string)) =>
-    setState((s) => ({ ...s, leanCode: typeof v === "function" ? v(s.leanCode) : v })), []);
-  const setSemiformalDirty = useCallback((v: boolean | ((prev: boolean) => boolean)) =>
-    setState((s) => ({ ...s, semiformalDirty: typeof v === "function" ? v(s.semiformalDirty) : v })), []);
-  const setVerificationStatus = useCallback((v: VerificationStatus) => setState((s) => ({ ...s, verificationStatus: v })), []);
-  const setVerificationErrors = useCallback((v: string) => setState((s) => ({ ...s, verificationErrors: v })), []);
-  const setCausalGraph = useCallback((v: string | null) => setState((s) => ({ ...s, causalGraph: v })), []);
-  const setStatisticalModel = useCallback((v: string | null) => setState((s) => ({ ...s, statisticalModel: v })), []);
-  const setPropertyTests = useCallback((v: string | null) => setState((s) => ({ ...s, propertyTests: v })), []);
-  const setDialecticalMap = useCallback((v: string | null) => setState((s) => ({ ...s, dialecticalMap: v })), []);
-  const setCounterexamples = useCallback((v: string | null) => setState((s) => ({ ...s, counterexamples: v })), []);
+  // Restored decomposition state: non-null when persisted decomposition has nodes.
+  // page.tsx guards against re-application with its own decompRestoredRef.
+  const restoredDecompState: PersistedDecomposition | null =
+    decomposition.nodes.length > 0 ? decomposition : null;
 
-  /** Build a PersistedWorkspace snapshot of the current state (synchronous) */
+  // Snapshot/restore: bridge between old PersistedWorkspace format and Zustand WorkspaceState
   const getSnapshot = useCallback((): PersistedWorkspace => {
-    const s = stateRef.current;
-    const a = artifactRef.current;
+    const s = useWorkspaceStore.getState();
     return {
       version: 2,
       sourceText: s.sourceText,
@@ -161,112 +118,85 @@ export function useWorkspacePersistence() {
       semiformalText: s.semiformalText,
       leanCode: s.leanCode,
       semiformalDirty: s.semiformalDirty,
-      verificationStatus: s.verificationStatus === "verifying" ? "none" : s.verificationStatus,
+      verificationStatus: sanitizeVerificationStatus(s.verificationStatus),
       verificationErrors: s.verificationErrors,
-      decomposition: { ...decompRef.current },
-      causalGraph: a.causalGraph,
-      statisticalModel: a.statisticalModel,
-      propertyTests: a.propertyTests,
-      dialecticalMap: a.dialecticalMap,
-      counterexamples: a.counterexamples,
+      decomposition: structuredClone(s.decomposition),
+      causalGraph: s.getArtifactContent("causal-graph"),
+      statisticalModel: s.getArtifactContent("statistical-model"),
+      propertyTests: s.getArtifactContent("property-tests"),
+      dialecticalMap: s.getArtifactContent("dialectical-map"),
+      counterexamples: s.getArtifactContent("counterexamples"),
     };
   }, []);
 
-  /** Replace all workspace state from a snapshot (used when switching workspace sessions) */
   const resetToSnapshot = useCallback((data: PersistedWorkspace): PersistedDecomposition => {
-    // Cancel any pending debounced save
-    if (timerRef.current) clearTimeout(timerRef.current);
+    const store = useWorkspaceStore.getState();
+    store.setSourceText(data.sourceText);
+    store.setExtractedFiles(data.extractedFiles);
+    store.setContextText(data.contextText);
+    store.setSemiformalText(data.semiformalText);
+    store.setLeanCode(data.leanCode);
+    store.setSemiformalDirty(data.semiformalDirty);
+    store.setVerificationStatus(data.verificationStatus);
+    store.setVerificationErrors(data.verificationErrors);
+    store.setDecomposition(data.decomposition);
 
-    setState({
-      sourceText: data.sourceText,
-      extractedFiles: data.extractedFiles,
-      contextText: data.contextText,
-      semiformalText: data.semiformalText,
-      leanCode: data.leanCode,
-      semiformalDirty: data.semiformalDirty,
-      verificationStatus: data.verificationStatus,
-      verificationErrors: data.verificationErrors,
-      causalGraph: data.causalGraph,
-      statisticalModel: data.statisticalModel,
-      propertyTests: data.propertyTests,
-      dialecticalMap: data.dialecticalMap,
-      counterexamples: data.counterexamples,
-    });
-
-    decompRef.current = data.decomposition;
-
-    // Write to localStorage immediately (no debounce for session switches)
-    saveWorkspace({
-      sourceText: data.sourceText,
-      extractedFiles: data.extractedFiles,
-      contextText: data.contextText,
-      semiformalText: data.semiformalText,
-      leanCode: data.leanCode,
-      semiformalDirty: data.semiformalDirty,
-      verificationStatus: data.verificationStatus,
-      verificationErrors: data.verificationErrors,
-      decomposition: data.decomposition,
-      artifacts: {
-        causalGraph: data.causalGraph,
-        statisticalModel: data.statisticalModel,
-        propertyTests: data.propertyTests,
-        dialecticalMap: data.dialecticalMap,
-        counterexamples: data.counterexamples,
-      },
-    });
+    // Restore artifact data
+    if (data.causalGraph) store.setArtifactGenerated("causal-graph", data.causalGraph);
+    if (data.statisticalModel) store.setArtifactGenerated("statistical-model", data.statisticalModel);
+    if (data.propertyTests) store.setArtifactGenerated("property-tests", data.propertyTests);
+    if (data.dialecticalMap) store.setArtifactGenerated("dialectical-map", data.dialecticalMap);
+    if (data.counterexamples) store.setArtifactGenerated("counterexamples", data.counterexamples);
 
     return data.decomposition;
   }, []);
 
-  /** Clear all workspace state back to defaults */
   const clearWorkspace = useCallback((): PersistedDecomposition => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-
-    setState(DEFAULT_STATE);
-
+    useWorkspaceStore.getState().clearWorkspace();
     const emptyDecomp: PersistedDecomposition = { nodes: [], selectedNodeId: null, paperText: "", sources: [] };
-    decompRef.current = emptyDecomp;
-
-    saveWorkspace({
-      ...DEFAULT_STATE,
-      decomposition: emptyDecomp,
-    });
-
     return emptyDecomp;
   }, []);
 
-  // Stable return object that destructures the same as before
   return useMemo(() => ({
-    sourceText: state.sourceText,
+    sourceText,
     setSourceText,
-    extractedFiles: state.extractedFiles,
+    extractedFiles,
     setExtractedFiles,
-    contextText: state.contextText,
+    contextText,
     setContextText,
-    semiformalText: state.semiformalText,
+    semiformalText,
     setSemiformalText,
-    leanCode: state.leanCode,
+    leanCode,
     setLeanCode,
-    semiformalDirty: state.semiformalDirty,
+    semiformalDirty,
     setSemiformalDirty,
-    verificationStatus: state.verificationStatus,
+    verificationStatus,
     setVerificationStatus,
-    verificationErrors: state.verificationErrors,
+    verificationErrors,
     setVerificationErrors,
-    causalGraph: state.causalGraph,
+    causalGraph,
     setCausalGraph,
-    statisticalModel: state.statisticalModel,
+    statisticalModel,
     setStatisticalModel,
-    propertyTests: state.propertyTests,
+    propertyTests,
     setPropertyTests,
-    dialecticalMap: state.dialecticalMap,
+    dialecticalMap,
     setDialecticalMap,
-    counterexamples: state.counterexamples,
+    counterexamples,
     setCounterexamples,
     restoredDecompState,
     persistDecompState,
     getSnapshot,
     resetToSnapshot,
     clearWorkspace,
-  }), [state, restoredDecompState, persistDecompState, setSourceText, setExtractedFiles, setContextText, setSemiformalText, setLeanCode, setSemiformalDirty, setVerificationStatus, setVerificationErrors, setCausalGraph, setStatisticalModel, setPropertyTests, setDialecticalMap, setCounterexamples, getSnapshot, resetToSnapshot, clearWorkspace]);
+  }), [
+    sourceText, setSourceText, extractedFiles, setExtractedFiles,
+    contextText, setContextText, semiformalText, setSemiformalText,
+    leanCode, setLeanCode, semiformalDirty, setSemiformalDirty,
+    verificationStatus, setVerificationStatus, verificationErrors, setVerificationErrors,
+    causalGraph, setCausalGraph, statisticalModel, setStatisticalModel,
+    propertyTests, setPropertyTests, dialecticalMap, setDialecticalMap,
+    counterexamples, setCounterexamples,
+    restoredDecompState, persistDecompState, getSnapshot, resetToSnapshot, clearWorkspace,
+  ]);
 }

--- a/app/hooks/useWorkspacePersistence.ts
+++ b/app/hooks/useWorkspacePersistence.ts
@@ -50,14 +50,12 @@ export function useWorkspacePersistence() {
   const setVerificationStatus = useWorkspaceStore((s) => s.setVerificationStatus);
   const setVerificationErrors = useWorkspaceStore((s) => s.setVerificationErrors);
 
-  // extractedFiles setter: the old API accepted { name, text, file? }[] but
-  // File objects can't be serialized. The store only keeps { name, text }.
-  // Callers that pass File objects will have them stripped on persistence.
+  // extractedFiles setter: the old API accepted { name, text, file? }[] and
+  // the store now carries the optional File in memory. The persist middleware's
+  // partialize strips File objects before writing to localStorage.
   const setExtractedFiles = useCallback(
     (v: { name: string; text: string; file?: File }[]) => {
-      useWorkspaceStore.getState().setExtractedFiles(
-        v.map(({ name, text }) => ({ name, text })),
-      );
+      useWorkspaceStore.getState().setExtractedFiles(v);
     },
     [],
   );

--- a/app/lib/stores/__tests__/workspaceStore-hydration.test.ts
+++ b/app/lib/stores/__tests__/workspaceStore-hydration.test.ts
@@ -1,0 +1,145 @@
+/**
+ * SPIKE: Test SSR hydration and migration from workspace-v2.
+ *
+ * Uses jsdom's built-in localStorage (vitest default env).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { useWorkspaceStore } from "../workspaceStore";
+
+beforeEach(() => {
+  localStorage.clear();
+  useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+});
+
+describe("SSR hydration", () => {
+  it("starts with defaults before hydration (SSR safe)", () => {
+    const state = useWorkspaceStore.getState();
+    expect(state.sourceText).toBe("");
+    expect(state.artifacts).toEqual({});
+  });
+
+  it("rehydrates from localStorage on rehydrate() call", async () => {
+    // Pre-populate localStorage with saved state (Zustand persist format)
+    const saved = {
+      state: {
+        sourceText: "persisted source",
+        extractedFiles: [],
+        contextText: "persisted context",
+        semiformalText: "",
+        leanCode: "",
+        semiformalDirty: false,
+        verificationStatus: "none",
+        verificationErrors: "",
+        artifacts: {
+          "causal-graph": {
+            type: "causal-graph",
+            currentVersionIndex: 0,
+            versions: [{
+              id: "test-id",
+              content: '{"variables":[]}',
+              createdAt: "2025-01-01T00:00:00Z",
+              source: "generated",
+            }],
+          },
+        },
+        decomposition: { nodes: [], selectedNodeId: null, paperText: "", sources: [] },
+      },
+      version: 0,
+    };
+    localStorage.setItem("workspace-zustand-v1", JSON.stringify(saved));
+
+    // Rehydrate (this is what useEffect would call in a component)
+    await useWorkspaceStore.persist.rehydrate();
+
+    const state = useWorkspaceStore.getState();
+    expect(state.sourceText).toBe("persisted source");
+    expect(state.contextText).toBe("persisted context");
+    expect(state.getArtifactContent("causal-graph")).toBe('{"variables":[]}');
+  });
+
+  it("persist middleware auto-saves on state change after hydration", async () => {
+    // First rehydrate (activates the persist listener)
+    await useWorkspaceStore.persist.rehydrate();
+
+    // Make a change
+    useWorkspaceStore.getState().setSourceText("auto-saved");
+
+    // Check localStorage was updated
+    const raw = localStorage.getItem("workspace-zustand-v1");
+    expect(raw).not.toBeNull();
+    const stored = JSON.parse(raw!);
+    expect(stored.state.sourceText).toBe("auto-saved");
+  });
+
+  it("persisted data excludes action functions", async () => {
+    await useWorkspaceStore.persist.rehydrate();
+    useWorkspaceStore.getState().setSourceText("test");
+
+    const stored = JSON.parse(localStorage.getItem("workspace-zustand-v1")!);
+    // Should not contain function keys
+    expect(stored.state.setSourceText).toBeUndefined();
+    expect(stored.state.setArtifactGenerated).toBeUndefined();
+    expect(stored.state.getSnapshot).toBeUndefined();
+  });
+});
+
+describe("migration from workspace-v2", () => {
+  it("can migrate old flat artifact fields to versioned store", () => {
+    const oldWorkspace = {
+      version: 2,
+      sourceText: "old source",
+      extractedFiles: [],
+      contextText: "old context",
+      semiformalText: "old proof",
+      leanCode: "old lean",
+      semiformalDirty: false,
+      verificationStatus: "none" as const,
+      verificationErrors: "",
+      decomposition: { nodes: [], selectedNodeId: null, paperText: "", sources: [] },
+      causalGraph: '{"variables":[],"edges":[]}',
+      statisticalModel: null,
+      propertyTests: '{"tests":[]}',
+      balancedPerspectives: null,
+      counterexamples: null,
+    };
+
+    // Migration function
+    function migrateFromV2(old: typeof oldWorkspace) {
+      const store = useWorkspaceStore.getState();
+      store.setSourceText(old.sourceText);
+      store.setContextText(old.contextText);
+      store.setSemiformalText(old.semiformalText);
+      store.setLeanCode(old.leanCode);
+      store.setVerificationStatus(old.verificationStatus);
+      store.setVerificationErrors(old.verificationErrors);
+      store.setDecomposition(old.decomposition);
+
+      const artifactMap: Record<string, string | null> = {
+        "causal-graph": old.causalGraph,
+        "statistical-model": old.statisticalModel,
+        "property-tests": old.propertyTests,
+        "balanced-perspectives": old.balancedPerspectives,
+        counterexamples: old.counterexamples,
+      };
+
+      for (const [key, content] of Object.entries(artifactMap)) {
+        if (content) {
+          store.setArtifactGenerated(key as "causal-graph", content);
+        }
+      }
+    }
+
+    migrateFromV2(oldWorkspace);
+
+    const store = useWorkspaceStore.getState();
+    expect(store.sourceText).toBe("old source");
+    expect(store.getArtifactContent("causal-graph")).toBe('{"variables":[],"edges":[]}');
+    expect(store.getArtifactContent("property-tests")).toBe('{"tests":[]}');
+    expect(store.getArtifactContent("statistical-model")).toBeNull();
+
+    const cgRec = store.artifacts["causal-graph"]!;
+    expect(cgRec.versions).toHaveLength(1);
+    expect(cgRec.versions[0].source).toBe("generated");
+  });
+});

--- a/app/lib/stores/__tests__/workspaceStore-hydration.test.ts
+++ b/app/lib/stores/__tests__/workspaceStore-hydration.test.ts
@@ -1,11 +1,10 @@
 /**
- * SPIKE: Test SSR hydration and migration from workspace-v2.
- *
- * Uses jsdom's built-in localStorage (vitest default env).
+ * Tests for SSR hydration and migration from workspace-v2 format.
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { useWorkspaceStore } from "../workspaceStore";
+import { useWorkspaceStore, migrateFromV2 } from "../workspaceStore";
+import { WORKSPACE_KEY } from "@/app/lib/types/persistence";
 
 beforeEach(() => {
   localStorage.clear();
@@ -20,7 +19,6 @@ describe("SSR hydration", () => {
   });
 
   it("rehydrates from localStorage on rehydrate() call", async () => {
-    // Pre-populate localStorage with saved state (Zustand persist format)
     const saved = {
       state: {
         sourceText: "persisted source",
@@ -49,7 +47,6 @@ describe("SSR hydration", () => {
     };
     localStorage.setItem("workspace-zustand-v1", JSON.stringify(saved));
 
-    // Rehydrate (this is what useEffect would call in a component)
     await useWorkspaceStore.persist.rehydrate();
 
     const state = useWorkspaceStore.getState();
@@ -59,13 +56,10 @@ describe("SSR hydration", () => {
   });
 
   it("persist middleware auto-saves on state change after hydration", async () => {
-    // First rehydrate (activates the persist listener)
     await useWorkspaceStore.persist.rehydrate();
 
-    // Make a change
     useWorkspaceStore.getState().setSourceText("auto-saved");
 
-    // Check localStorage was updated
     const raw = localStorage.getItem("workspace-zustand-v1");
     expect(raw).not.toBeNull();
     const stored = JSON.parse(raw!);
@@ -77,7 +71,6 @@ describe("SSR hydration", () => {
     useWorkspaceStore.getState().setSourceText("test");
 
     const stored = JSON.parse(localStorage.getItem("workspace-zustand-v1")!);
-    // Should not contain function keys
     expect(stored.state.setSourceText).toBeUndefined();
     expect(stored.state.setArtifactGenerated).toBeUndefined();
     expect(stored.state.getSnapshot).toBeUndefined();
@@ -85,61 +78,97 @@ describe("SSR hydration", () => {
 });
 
 describe("migration from workspace-v2", () => {
-  it("can migrate old flat artifact fields to versioned store", () => {
-    const oldWorkspace = {
+  it("migrates old flat artifact fields to versioned store", () => {
+    // Simulate old workspace-v2 data in localStorage
+    const oldData = {
       version: 2,
       sourceText: "old source",
-      extractedFiles: [],
+      extractedFiles: [{ name: "test.txt", text: "file content" }],
       contextText: "old context",
       semiformalText: "old proof",
       leanCode: "old lean",
       semiformalDirty: false,
-      verificationStatus: "none" as const,
+      verificationStatus: "none",
       verificationErrors: "",
       decomposition: { nodes: [], selectedNodeId: null, paperText: "", sources: [] },
       causalGraph: '{"variables":[],"edges":[]}',
       statisticalModel: null,
       propertyTests: '{"tests":[]}',
-      balancedPerspectives: null,
+      dialecticalMap: '{"positions":[]}',
       counterexamples: null,
     };
+    localStorage.setItem(WORKSPACE_KEY, JSON.stringify(oldData));
 
-    // Migration function
-    function migrateFromV2(old: typeof oldWorkspace) {
-      const store = useWorkspaceStore.getState();
-      store.setSourceText(old.sourceText);
-      store.setContextText(old.contextText);
-      store.setSemiformalText(old.semiformalText);
-      store.setLeanCode(old.leanCode);
-      store.setVerificationStatus(old.verificationStatus);
-      store.setVerificationErrors(old.verificationErrors);
-      store.setDecomposition(old.decomposition);
-
-      const artifactMap: Record<string, string | null> = {
-        "causal-graph": old.causalGraph,
-        "statistical-model": old.statisticalModel,
-        "property-tests": old.propertyTests,
-        "balanced-perspectives": old.balancedPerspectives,
-        counterexamples: old.counterexamples,
-      };
-
-      for (const [key, content] of Object.entries(artifactMap)) {
-        if (content) {
-          store.setArtifactGenerated(key as "causal-graph", content);
-        }
-      }
-    }
-
-    migrateFromV2(oldWorkspace);
+    const success = migrateFromV2();
+    expect(success).toBe(true);
 
     const store = useWorkspaceStore.getState();
     expect(store.sourceText).toBe("old source");
+    expect(store.contextText).toBe("old context");
+    expect(store.semiformalText).toBe("old proof");
+    expect(store.leanCode).toBe("old lean");
+    expect(store.extractedFiles).toEqual([{ name: "test.txt", text: "file content" }]);
+
     expect(store.getArtifactContent("causal-graph")).toBe('{"variables":[],"edges":[]}');
     expect(store.getArtifactContent("property-tests")).toBe('{"tests":[]}');
+    expect(store.getArtifactContent("dialectical-map")).toBe('{"positions":[]}');
     expect(store.getArtifactContent("statistical-model")).toBeNull();
+    expect(store.getArtifactContent("counterexamples")).toBeNull();
 
+    // Migrated artifacts should have a single "generated" version
     const cgRec = store.artifacts["causal-graph"]!;
     expect(cgRec.versions).toHaveLength(1);
     expect(cgRec.versions[0].source).toBe("generated");
+  });
+
+  it("returns false when no workspace-v2 data exists", () => {
+    const success = migrateFromV2();
+    expect(success).toBe(false);
+  });
+
+  it("preserves decomposition state during migration", () => {
+    const nodes = [{
+      id: "n1",
+      label: "Prop 1",
+      kind: "proposition",
+      statement: "test statement",
+      proofText: "",
+      dependsOn: [],
+      sourceId: "doc-0",
+      sourceLabel: "Text Input",
+      semiformalProof: "",
+      leanCode: "",
+      verificationStatus: "unverified",
+      verificationErrors: "",
+      context: "",
+      selectedArtifactTypes: [],
+      artifacts: [],
+    }];
+    const oldData = {
+      version: 2,
+      sourceText: "",
+      extractedFiles: [],
+      contextText: "",
+      semiformalText: "",
+      leanCode: "",
+      semiformalDirty: false,
+      verificationStatus: "none",
+      verificationErrors: "",
+      decomposition: { nodes, selectedNodeId: "n1", paperText: "test paper", sources: [] },
+      causalGraph: null,
+      statisticalModel: null,
+      propertyTests: null,
+      dialecticalMap: null,
+      counterexamples: null,
+    };
+    localStorage.setItem(WORKSPACE_KEY, JSON.stringify(oldData));
+
+    migrateFromV2();
+
+    const store = useWorkspaceStore.getState();
+    expect(store.decomposition.nodes).toHaveLength(1);
+    expect(store.decomposition.nodes[0].id).toBe("n1");
+    expect(store.decomposition.selectedNodeId).toBe("n1");
+    expect(store.decomposition.paperText).toBe("test paper");
   });
 });

--- a/app/lib/stores/__tests__/workspaceStore.test.ts
+++ b/app/lib/stores/__tests__/workspaceStore.test.ts
@@ -1,20 +1,19 @@
 /**
- * SPIKE: Validate Zustand store for workspace state management.
+ * Workspace Zustand store tests.
  *
- * Tests:
+ * Covers:
  * 1. Basic state get/set
- * 2. Artifact versioning (generate, edit, undo, redo)
+ * 2. Artifact versioning (generate, edit, undo, redo, cap)
  * 3. Snapshot/restore (workspace sessions)
  * 4. PipelineAccessors compatibility
- * 5. Selective subscriptions (React component won't re-render for unrelated changes)
- * 6. persist middleware hydration
+ * 5. Selective subscriptions
+ * 6. Backward-compatible artifact access
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useWorkspaceStore } from "../workspaceStore";
 import type { PipelineAccessors } from "@/app/hooks/useFormalizationPipeline";
 
-// Reset store between tests
 beforeEach(() => {
   useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
 });
@@ -49,6 +48,18 @@ describe("workspaceStore", () => {
     expect(useWorkspaceStore.getState().leanCode).toBe("theorem p");
   });
 
+  it("supports functional updates for semiformalDirty", () => {
+    const { setSemiformalDirty } = useWorkspaceStore.getState();
+    setSemiformalDirty(false);
+    expect(useWorkspaceStore.getState().semiformalDirty).toBe(false);
+
+    setSemiformalDirty((prev) => !prev);
+    expect(useWorkspaceStore.getState().semiformalDirty).toBe(true);
+
+    setSemiformalDirty((prev) => prev || false);
+    expect(useWorkspaceStore.getState().semiformalDirty).toBe(true);
+  });
+
   // -------------------------------------------------------------------------
   // 2. Artifact versioning
   // -------------------------------------------------------------------------
@@ -62,11 +73,8 @@ describe("workspaceStore", () => {
 
     it("preserves edit history across regeneration", () => {
       const store = useWorkspaceStore.getState();
-      // Generate v1
       store.setArtifactGenerated("causal-graph", "v1-generated");
-      // User edits → v2
       store.setArtifactEdited("causal-graph", "v2-edited", "ai-edit", "add node X");
-      // Regenerate → v3
       store.setArtifactGenerated("causal-graph", "v3-regenerated");
 
       const rec = useWorkspaceStore.getState().artifacts["causal-graph"]!;
@@ -108,7 +116,6 @@ describe("workspaceStore", () => {
       store.setArtifactEdited("causal-graph", "v2", "manual-edit");
       store.setArtifactEdited("causal-graph", "v3", "manual-edit");
 
-      // Undo to v2, then make a new edit → v3 is gone
       store.undoArtifact("causal-graph");
       store.setArtifactEdited("causal-graph", "v2-fork", "manual-edit");
 
@@ -125,8 +132,17 @@ describe("workspaceStore", () => {
       }
       const rec = useWorkspaceStore.getState().artifacts["causal-graph"]!;
       expect(rec.versions.length).toBeLessThanOrEqual(20);
-      // Latest should still be the last one
       expect(store.getArtifactContent("causal-graph")).toBe("v24");
+    });
+
+    it("works with dialectical-map artifact key", () => {
+      const store = useWorkspaceStore.getState();
+      store.setArtifactGenerated("dialectical-map", '{"positions":[]}');
+      expect(store.getArtifactContent("dialectical-map")).toBe('{"positions":[]}');
+
+      store.setArtifactEdited("dialectical-map", '{"positions":["a"]}', "manual-edit");
+      expect(store.getArtifactContent("dialectical-map")).toBe('{"positions":["a"]}');
+      expect(store.canUndo("dialectical-map")).toBe(true);
     });
   });
 
@@ -143,12 +159,10 @@ describe("workspaceStore", () => {
 
       const snapshot = store.getSnapshot();
 
-      // Clear everything
       store.clearWorkspace();
       expect(store.getArtifactContent("causal-graph")).toBeNull();
       expect(useWorkspaceStore.getState().sourceText).toBe("");
 
-      // Restore
       store.resetToSnapshot(snapshot);
       expect(useWorkspaceStore.getState().sourceText).toBe("my source");
       expect(store.getArtifactContent("causal-graph")).toBe("graph-data");
@@ -160,10 +174,8 @@ describe("workspaceStore", () => {
       store.setArtifactGenerated("causal-graph", "original");
       const snapshot = store.getSnapshot();
 
-      // Mutate store after snapshot
       store.setArtifactEdited("causal-graph", "mutated", "manual-edit");
 
-      // Snapshot should still have original
       expect(snapshot.artifacts["causal-graph"]!.versions).toHaveLength(1);
       expect(snapshot.artifacts["causal-graph"]!.versions[0].content).toBe("original");
     });
@@ -174,9 +186,6 @@ describe("workspaceStore", () => {
   // -------------------------------------------------------------------------
   describe("pipeline accessors", () => {
     it("can build PipelineAccessors from store methods", () => {
-      // This is the pattern page.tsx would use: build accessors from store
-      const store = useWorkspaceStore.getState();
-
       const accessors: PipelineAccessors = {
         getSemiformal: () => useWorkspaceStore.getState().semiformalText,
         setSemiformal: (text) => useWorkspaceStore.getState().setSemiformalText(text),
@@ -187,7 +196,6 @@ describe("workspaceStore", () => {
         setVerificationErrors: (e) => useWorkspaceStore.getState().setVerificationErrors(e),
       };
 
-      // Simulate pipeline usage
       accessors.setSemiformal("proof step 1");
       expect(accessors.getSemiformal()).toBe("proof step 1");
 
@@ -199,7 +207,6 @@ describe("workspaceStore", () => {
     });
 
     it("accessors always read fresh state (no stale closures)", () => {
-      // Key advantage over useState: getState() always returns latest
       const accessors: PipelineAccessors = {
         getSemiformal: () => useWorkspaceStore.getState().semiformalText,
         setSemiformal: (text) => useWorkspaceStore.getState().setSemiformalText(text),
@@ -210,10 +217,7 @@ describe("workspaceStore", () => {
         setVerificationErrors: (e) => useWorkspaceStore.getState().setVerificationErrors(e),
       };
 
-      // External code changes state
       useWorkspaceStore.getState().setSemiformalText("externally set");
-
-      // Accessor sees the change immediately (no stale closure!)
       expect(accessors.getSemiformal()).toBe("externally set");
     });
   });
@@ -222,21 +226,13 @@ describe("workspaceStore", () => {
   // 5. Selective subscriptions
   // -------------------------------------------------------------------------
   describe("selective subscriptions", () => {
-    it("subscribe fires for all state changes (use useStore selector in React for selective re-renders)", () => {
+    it("subscribe fires for all state changes", () => {
       const listener = vi.fn();
-
-      // Zustand v5: vanilla subscribe fires on every change.
-      // Selective re-renders happen in React via useStore(store, selector).
-      // This test validates that the subscribe API works and that
-      // React components should use selectors for performance.
       const unsub = useWorkspaceStore.subscribe(listener);
 
       useWorkspaceStore.getState().setSourceText("changed");
       expect(listener).toHaveBeenCalledTimes(1);
 
-      // Vanilla subscribe fires for all changes — this is expected.
-      // React: useWorkspaceStore((s) => s.sourceText) only re-renders
-      // when sourceText changes, not when contextText changes.
       useWorkspaceStore.getState().setContextText("other change");
       expect(listener).toHaveBeenCalledTimes(2);
 
@@ -245,23 +241,20 @@ describe("workspaceStore", () => {
   });
 
   // -------------------------------------------------------------------------
-  // 6. Backward-compatible artifact access pattern
+  // 6. Backward-compatible artifact access
   // -------------------------------------------------------------------------
-  describe("backward compat shim", () => {
+  describe("backward compat", () => {
     it("getArtifactContent returns null for missing artifacts", () => {
       const store = useWorkspaceStore.getState();
       expect(store.getArtifactContent("causal-graph")).toBeNull();
       expect(store.getArtifactContent("statistical-model")).toBeNull();
+      expect(store.getArtifactContent("dialectical-map")).toBeNull();
     });
 
     it("can simulate the old setter pattern via setArtifactGenerated", () => {
-      // Old pattern: setPersistedCausalGraph('{"data": "..."}')
-      // New pattern: setArtifactGenerated("causal-graph", '{"data": "..."}')
       const store = useWorkspaceStore.getState();
       store.setArtifactGenerated("causal-graph", '{"variables":[],"edges":[]}');
 
-      // Old read pattern: parseJson(persistedCausalGraph)
-      // New: getArtifactContent("causal-graph") then JSON.parse
       const content = store.getArtifactContent("causal-graph");
       expect(content).not.toBeNull();
       const parsed = JSON.parse(content!);

--- a/app/lib/stores/__tests__/workspaceStore.test.ts
+++ b/app/lib/stores/__tests__/workspaceStore.test.ts
@@ -1,0 +1,272 @@
+/**
+ * SPIKE: Validate Zustand store for workspace state management.
+ *
+ * Tests:
+ * 1. Basic state get/set
+ * 2. Artifact versioning (generate, edit, undo, redo)
+ * 3. Snapshot/restore (workspace sessions)
+ * 4. PipelineAccessors compatibility
+ * 5. Selective subscriptions (React component won't re-render for unrelated changes)
+ * 6. persist middleware hydration
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useWorkspaceStore } from "../workspaceStore";
+import type { PipelineAccessors } from "@/app/hooks/useFormalizationPipeline";
+
+// Reset store between tests
+beforeEach(() => {
+  useWorkspaceStore.setState(useWorkspaceStore.getInitialState());
+});
+
+describe("workspaceStore", () => {
+  // -------------------------------------------------------------------------
+  // 1. Basic state
+  // -------------------------------------------------------------------------
+  it("initializes with defaults", () => {
+    const state = useWorkspaceStore.getState();
+    expect(state.sourceText).toBe("");
+    expect(state.artifacts).toEqual({});
+    expect(state.decomposition.nodes).toEqual([]);
+  });
+
+  it("updates simple fields", () => {
+    const { setSourceText, setContextText } = useWorkspaceStore.getState();
+    setSourceText("hello");
+    setContextText("world");
+    expect(useWorkspaceStore.getState().sourceText).toBe("hello");
+    expect(useWorkspaceStore.getState().contextText).toBe("world");
+  });
+
+  it("supports functional updates for semiformal/lean", () => {
+    const { setSemiformalText, setLeanCode } = useWorkspaceStore.getState();
+    setSemiformalText("base");
+    setSemiformalText((prev) => prev + " appended");
+    expect(useWorkspaceStore.getState().semiformalText).toBe("base appended");
+
+    setLeanCode("theorem");
+    setLeanCode((prev) => prev + " p");
+    expect(useWorkspaceStore.getState().leanCode).toBe("theorem p");
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Artifact versioning
+  // -------------------------------------------------------------------------
+  describe("artifact versioning", () => {
+    it("creates a record on first generation", () => {
+      const { setArtifactGenerated, getArtifactContent } = useWorkspaceStore.getState();
+      setArtifactGenerated("causal-graph", '{"variables":[]}');
+      expect(getArtifactContent("causal-graph")).toBe('{"variables":[]}');
+      expect(useWorkspaceStore.getState().artifacts["causal-graph"]!.versions).toHaveLength(1);
+    });
+
+    it("preserves edit history across regeneration", () => {
+      const store = useWorkspaceStore.getState();
+      // Generate v1
+      store.setArtifactGenerated("causal-graph", "v1-generated");
+      // User edits → v2
+      store.setArtifactEdited("causal-graph", "v2-edited", "ai-edit", "add node X");
+      // Regenerate → v3
+      store.setArtifactGenerated("causal-graph", "v3-regenerated");
+
+      const rec = useWorkspaceStore.getState().artifacts["causal-graph"]!;
+      expect(rec.versions).toHaveLength(3);
+      expect(rec.versions[0].content).toBe("v1-generated");
+      expect(rec.versions[1].content).toBe("v2-edited");
+      expect(rec.versions[1].source).toBe("ai-edit");
+      expect(rec.versions[1].editInstruction).toBe("add node X");
+      expect(rec.versions[2].content).toBe("v3-regenerated");
+      expect(store.getArtifactContent("causal-graph")).toBe("v3-regenerated");
+    });
+
+    it("supports undo and redo", () => {
+      const store = useWorkspaceStore.getState();
+      store.setArtifactGenerated("causal-graph", "v1");
+      store.setArtifactEdited("causal-graph", "v2", "manual-edit");
+      store.setArtifactEdited("causal-graph", "v3", "manual-edit");
+
+      expect(store.getArtifactContent("causal-graph")).toBe("v3");
+      expect(store.canUndo("causal-graph")).toBe(true);
+      expect(store.canRedo("causal-graph")).toBe(false);
+
+      store.undoArtifact("causal-graph");
+      expect(store.getArtifactContent("causal-graph")).toBe("v2");
+      expect(store.canUndo("causal-graph")).toBe(true);
+      expect(store.canRedo("causal-graph")).toBe(true);
+
+      store.undoArtifact("causal-graph");
+      expect(store.getArtifactContent("causal-graph")).toBe("v1");
+      expect(store.canUndo("causal-graph")).toBe(false);
+
+      store.redoArtifact("causal-graph");
+      expect(store.getArtifactContent("causal-graph")).toBe("v2");
+    });
+
+    it("truncates redo history on new edit", () => {
+      const store = useWorkspaceStore.getState();
+      store.setArtifactGenerated("causal-graph", "v1");
+      store.setArtifactEdited("causal-graph", "v2", "manual-edit");
+      store.setArtifactEdited("causal-graph", "v3", "manual-edit");
+
+      // Undo to v2, then make a new edit → v3 is gone
+      store.undoArtifact("causal-graph");
+      store.setArtifactEdited("causal-graph", "v2-fork", "manual-edit");
+
+      const rec = useWorkspaceStore.getState().artifacts["causal-graph"]!;
+      expect(rec.versions).toHaveLength(3); // v1, v2, v2-fork (v3 discarded)
+      expect(store.getArtifactContent("causal-graph")).toBe("v2-fork");
+      expect(store.canRedo("causal-graph")).toBe(false);
+    });
+
+    it("caps versions at 20", () => {
+      const store = useWorkspaceStore.getState();
+      for (let i = 0; i < 25; i++) {
+        store.setArtifactGenerated("causal-graph", `v${i}`);
+      }
+      const rec = useWorkspaceStore.getState().artifacts["causal-graph"]!;
+      expect(rec.versions.length).toBeLessThanOrEqual(20);
+      // Latest should still be the last one
+      expect(store.getArtifactContent("causal-graph")).toBe("v24");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Snapshot/restore
+  // -------------------------------------------------------------------------
+  describe("snapshot/restore", () => {
+    it("captures and restores full state", () => {
+      const store = useWorkspaceStore.getState();
+      store.setSourceText("my source");
+      store.setContextText("my context");
+      store.setArtifactGenerated("causal-graph", "graph-data");
+      store.setSemiformalText("proof text");
+
+      const snapshot = store.getSnapshot();
+
+      // Clear everything
+      store.clearWorkspace();
+      expect(store.getArtifactContent("causal-graph")).toBeNull();
+      expect(useWorkspaceStore.getState().sourceText).toBe("");
+
+      // Restore
+      store.resetToSnapshot(snapshot);
+      expect(useWorkspaceStore.getState().sourceText).toBe("my source");
+      expect(store.getArtifactContent("causal-graph")).toBe("graph-data");
+      expect(useWorkspaceStore.getState().semiformalText).toBe("proof text");
+    });
+
+    it("snapshot is a deep copy (mutations don't affect store)", () => {
+      const store = useWorkspaceStore.getState();
+      store.setArtifactGenerated("causal-graph", "original");
+      const snapshot = store.getSnapshot();
+
+      // Mutate store after snapshot
+      store.setArtifactEdited("causal-graph", "mutated", "manual-edit");
+
+      // Snapshot should still have original
+      expect(snapshot.artifacts["causal-graph"]!.versions).toHaveLength(1);
+      expect(snapshot.artifacts["causal-graph"]!.versions[0].content).toBe("original");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. PipelineAccessors compatibility
+  // -------------------------------------------------------------------------
+  describe("pipeline accessors", () => {
+    it("can build PipelineAccessors from store methods", () => {
+      // This is the pattern page.tsx would use: build accessors from store
+      const store = useWorkspaceStore.getState();
+
+      const accessors: PipelineAccessors = {
+        getSemiformal: () => useWorkspaceStore.getState().semiformalText,
+        setSemiformal: (text) => useWorkspaceStore.getState().setSemiformalText(text),
+        getLeanCode: () => useWorkspaceStore.getState().leanCode,
+        setLeanCode: (code) => useWorkspaceStore.getState().setLeanCode(code),
+        setVerificationStatus: (s) => useWorkspaceStore.getState().setVerificationStatus(s),
+        getVerificationErrors: () => useWorkspaceStore.getState().verificationErrors,
+        setVerificationErrors: (e) => useWorkspaceStore.getState().setVerificationErrors(e),
+      };
+
+      // Simulate pipeline usage
+      accessors.setSemiformal("proof step 1");
+      expect(accessors.getSemiformal()).toBe("proof step 1");
+
+      accessors.setLeanCode("theorem foo : True := trivial");
+      expect(accessors.getLeanCode()).toBe("theorem foo : True := trivial");
+
+      accessors.setVerificationStatus("valid");
+      expect(useWorkspaceStore.getState().verificationStatus).toBe("valid");
+    });
+
+    it("accessors always read fresh state (no stale closures)", () => {
+      // Key advantage over useState: getState() always returns latest
+      const accessors: PipelineAccessors = {
+        getSemiformal: () => useWorkspaceStore.getState().semiformalText,
+        setSemiformal: (text) => useWorkspaceStore.getState().setSemiformalText(text),
+        getLeanCode: () => useWorkspaceStore.getState().leanCode,
+        setLeanCode: (code) => useWorkspaceStore.getState().setLeanCode(code),
+        setVerificationStatus: (s) => useWorkspaceStore.getState().setVerificationStatus(s),
+        getVerificationErrors: () => useWorkspaceStore.getState().verificationErrors,
+        setVerificationErrors: (e) => useWorkspaceStore.getState().setVerificationErrors(e),
+      };
+
+      // External code changes state
+      useWorkspaceStore.getState().setSemiformalText("externally set");
+
+      // Accessor sees the change immediately (no stale closure!)
+      expect(accessors.getSemiformal()).toBe("externally set");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Selective subscriptions
+  // -------------------------------------------------------------------------
+  describe("selective subscriptions", () => {
+    it("subscribe fires for all state changes (use useStore selector in React for selective re-renders)", () => {
+      const listener = vi.fn();
+
+      // Zustand v5: vanilla subscribe fires on every change.
+      // Selective re-renders happen in React via useStore(store, selector).
+      // This test validates that the subscribe API works and that
+      // React components should use selectors for performance.
+      const unsub = useWorkspaceStore.subscribe(listener);
+
+      useWorkspaceStore.getState().setSourceText("changed");
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // Vanilla subscribe fires for all changes — this is expected.
+      // React: useWorkspaceStore((s) => s.sourceText) only re-renders
+      // when sourceText changes, not when contextText changes.
+      useWorkspaceStore.getState().setContextText("other change");
+      expect(listener).toHaveBeenCalledTimes(2);
+
+      unsub();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Backward-compatible artifact access pattern
+  // -------------------------------------------------------------------------
+  describe("backward compat shim", () => {
+    it("getArtifactContent returns null for missing artifacts", () => {
+      const store = useWorkspaceStore.getState();
+      expect(store.getArtifactContent("causal-graph")).toBeNull();
+      expect(store.getArtifactContent("statistical-model")).toBeNull();
+    });
+
+    it("can simulate the old setter pattern via setArtifactGenerated", () => {
+      // Old pattern: setPersistedCausalGraph('{"data": "..."}')
+      // New pattern: setArtifactGenerated("causal-graph", '{"data": "..."}')
+      const store = useWorkspaceStore.getState();
+      store.setArtifactGenerated("causal-graph", '{"variables":[],"edges":[]}');
+
+      // Old read pattern: parseJson(persistedCausalGraph)
+      // New: getArtifactContent("causal-graph") then JSON.parse
+      const content = store.getArtifactContent("causal-graph");
+      expect(content).not.toBeNull();
+      const parsed = JSON.parse(content!);
+      expect(parsed.variables).toEqual([]);
+      expect(parsed.edges).toEqual([]);
+    });
+  });
+});

--- a/app/lib/stores/workspaceStore.ts
+++ b/app/lib/stores/workspaceStore.ts
@@ -46,7 +46,7 @@ function makeVersion(
 export interface WorkspaceState {
   // --- Source inputs ---
   sourceText: string;
-  extractedFiles: { name: string; text: string }[];
+  extractedFiles: { name: string; text: string; file?: File }[];
   contextText: string;
 
   // --- Deductive artifacts (flat fields for pipeline compatibility) ---
@@ -305,7 +305,7 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
       // Only persist data fields, not action functions
       partialize: (state) => ({
         sourceText: state.sourceText,
-        extractedFiles: state.extractedFiles,
+        extractedFiles: state.extractedFiles.map(({ name, text }) => ({ name, text })),
         contextText: state.contextText,
         semiformalText: state.semiformalText,
         leanCode: state.leanCode,

--- a/app/lib/stores/workspaceStore.ts
+++ b/app/lib/stores/workspaceStore.ts
@@ -1,38 +1,29 @@
 /**
- * SPIKE: Zustand store replacing useWorkspacePersistence
+ * Zustand workspace store — replaces useWorkspacePersistence.
  *
- * Validates:
- * 1. persist middleware for localStorage (replaces manual debounce)
- * 2. Artifact versioning layer (edit history, undo/redo)
- * 3. Compatibility with PipelineAccessors pattern
- * 4. SSR-safe hydration (skipHydration + manual rehydrate)
- * 5. Snapshot/restore for workspace sessions
+ * Key design decisions:
+ * - persist middleware replaces manual debounce/localStorage pattern
+ * - skipHydration: true for Next.js SSR safety (call rehydrate() in useEffect)
+ * - partialize excludes action functions from persistence
+ * - Structured artifacts use ArtifactRecord with version history (undo/redo)
+ * - Semiformal/lean kept as flat strings for pipeline compatibility
+ * - Streaming preview state stays outside this store (persist writes on every set())
+ *
+ * See docs/decisions/005-zustand-state-management.md for rationale.
  */
 
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
-import type { VerificationStatus, ArtifactType } from "@/app/lib/types/session";
-import type { PersistedDecomposition } from "@/app/lib/types/persistence";
+import type { VerificationStatus } from "@/app/lib/types/session";
+import type { PersistedDecomposition, PersistedWorkspace } from "@/app/lib/types/persistence";
+import type { ArtifactKey, ArtifactVersion, ArtifactRecord } from "@/app/lib/types/artifactStore";
+import { MAX_VERSIONS } from "@/app/lib/types/artifactStore";
+import { loadWorkspace } from "@/app/lib/utils/workspacePersistence";
+import { WORKSPACE_KEY } from "@/app/lib/types/persistence";
 
 // ---------------------------------------------------------------------------
-// Artifact versioning types
+// Helpers
 // ---------------------------------------------------------------------------
-
-type ArtifactVersion = {
-  id: string;
-  content: string;
-  createdAt: string;
-  source: "generated" | "ai-edit" | "manual-edit";
-  editInstruction?: string;
-};
-
-type ArtifactRecord = {
-  type: ArtifactType;
-  currentVersionIndex: number; // pointer into versions[]
-  versions: ArtifactVersion[]; // oldest-first, capped at MAX_VERSIONS
-};
-
-const MAX_VERSIONS = 20;
 
 function makeVersion(
   content: string,
@@ -52,20 +43,13 @@ function makeVersion(
 // Store shape
 // ---------------------------------------------------------------------------
 
-type ArtifactKey =
-  | "causal-graph"
-  | "statistical-model"
-  | "property-tests"
-  | "balanced-perspectives"
-  | "counterexamples";
-
-interface WorkspaceState {
+export interface WorkspaceState {
   // --- Source inputs ---
   sourceText: string;
   extractedFiles: { name: string; text: string }[];
   contextText: string;
 
-  // --- Deductive artifacts (legacy flat fields, kept for pipeline compat) ---
+  // --- Deductive artifacts (flat fields for pipeline compatibility) ---
   semiformalText: string;
   leanCode: string;
   semiformalDirty: boolean;
@@ -79,14 +63,14 @@ interface WorkspaceState {
   decomposition: PersistedDecomposition;
 }
 
-interface WorkspaceActions {
+export interface WorkspaceActions {
   // Simple setters
   setSourceText: (v: string) => void;
   setExtractedFiles: (v: { name: string; text: string }[]) => void;
   setContextText: (v: string) => void;
   setSemiformalText: (v: string | ((prev: string) => string)) => void;
   setLeanCode: (v: string | ((prev: string) => string)) => void;
-  setSemiformalDirty: (v: boolean) => void;
+  setSemiformalDirty: (v: boolean | ((prev: boolean) => boolean)) => void;
   setVerificationStatus: (v: VerificationStatus) => void;
   setVerificationErrors: (v: string) => void;
 
@@ -131,6 +115,49 @@ const DEFAULT_STATE: WorkspaceState = {
 };
 
 // ---------------------------------------------------------------------------
+// Migration from workspace-v2 (old useWorkspacePersistence format)
+// ---------------------------------------------------------------------------
+
+/** Map from old flat persistence fields to versioned ArtifactKey */
+const V2_ARTIFACT_FIELDS: Record<string, ArtifactKey> = {
+  causalGraph: "causal-graph",
+  statisticalModel: "statistical-model",
+  propertyTests: "property-tests",
+  dialecticalMap: "dialectical-map",
+  counterexamples: "counterexamples",
+};
+
+/**
+ * Migrate data from workspace-v2 localStorage format into the Zustand store.
+ * Called once on app load if the Zustand key is absent but workspace-v2 exists.
+ */
+export function migrateFromV2(): boolean {
+  const old = loadWorkspace();
+  if (!old) return false;
+
+  const store = useWorkspaceStore.getState();
+  store.setSourceText(old.sourceText);
+  store.setExtractedFiles(old.extractedFiles);
+  store.setContextText(old.contextText);
+  store.setSemiformalText(old.semiformalText);
+  store.setLeanCode(old.leanCode);
+  store.setSemiformalDirty(old.semiformalDirty);
+  store.setVerificationStatus(old.verificationStatus);
+  store.setVerificationErrors(old.verificationErrors);
+  store.setDecomposition(old.decomposition);
+
+  // Migrate flat artifact JSON strings to versioned records
+  for (const [field, key] of Object.entries(V2_ARTIFACT_FIELDS)) {
+    const content = old[field as keyof PersistedWorkspace];
+    if (typeof content === "string" && content) {
+      store.setArtifactGenerated(key, content);
+    }
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
 // Store
 // ---------------------------------------------------------------------------
 
@@ -151,7 +178,10 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
         set((s) => ({
           leanCode: typeof v === "function" ? v(s.leanCode) : v,
         })),
-      setSemiformalDirty: (v) => set({ semiformalDirty: v }),
+      setSemiformalDirty: (v) =>
+        set((s) => ({
+          semiformalDirty: typeof v === "function" ? v(s.semiformalDirty) : v,
+        })),
       setVerificationStatus: (v) => set({ verificationStatus: v }),
       setVerificationErrors: (v) => set({ verificationErrors: v }),
 
@@ -179,7 +209,6 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
         set((s) => {
           const existing = s.artifacts[key];
           if (!existing) {
-            // No existing record — create one with this edit as first version
             const version = makeVersion(content, source, instruction);
             return {
               artifacts: {
@@ -188,7 +217,7 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
               },
             };
           }
-          // Truncate any "future" versions (redo history) when making a new edit
+          // Truncate redo history when making a new edit
           const version = makeVersion(content, source, instruction);
           const truncated = existing.versions.slice(0, existing.currentVersionIndex + 1);
           const versions = [...truncated.slice(-MAX_VERSIONS + 1), version];
@@ -269,11 +298,11 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
       clearWorkspace: () => set({ ...DEFAULT_STATE }),
     }),
     {
-      name: "workspace-zustand-v1", // localStorage key
+      name: "workspace-zustand-v1",
       storage: createJSONStorage(() => localStorage),
-      // skipHydration: true — SSR safe. Call rehydrate() in a useEffect.
+      // SSR safe: render defaults first, hydrate in useEffect via rehydrate()
       skipHydration: true,
-      // Only persist data, not actions
+      // Only persist data fields, not action functions
       partialize: (state) => ({
         sourceText: state.sourceText,
         extractedFiles: state.extractedFiles,
@@ -286,6 +315,21 @@ export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
         artifacts: state.artifacts,
         decomposition: state.decomposition,
       }),
+      // On rehydrate, check if we need to migrate from workspace-v2
+      onRehydrateStorage: () => {
+        return (_state, error) => {
+          if (error) return;
+          // If Zustand store was empty (no persisted data) but workspace-v2 exists,
+          // migrate the old data. We check by looking for the old key.
+          if (typeof window !== "undefined" && localStorage.getItem(WORKSPACE_KEY)) {
+            const zustandRaw = localStorage.getItem("workspace-zustand-v1");
+            const hasZustandData = zustandRaw && JSON.parse(zustandRaw)?.state?.sourceText;
+            if (!hasZustandData) {
+              migrateFromV2();
+            }
+          }
+        };
+      },
     },
   ),
 );

--- a/app/lib/stores/workspaceStore.ts
+++ b/app/lib/stores/workspaceStore.ts
@@ -1,0 +1,291 @@
+/**
+ * SPIKE: Zustand store replacing useWorkspacePersistence
+ *
+ * Validates:
+ * 1. persist middleware for localStorage (replaces manual debounce)
+ * 2. Artifact versioning layer (edit history, undo/redo)
+ * 3. Compatibility with PipelineAccessors pattern
+ * 4. SSR-safe hydration (skipHydration + manual rehydrate)
+ * 5. Snapshot/restore for workspace sessions
+ */
+
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type { VerificationStatus, ArtifactType } from "@/app/lib/types/session";
+import type { PersistedDecomposition } from "@/app/lib/types/persistence";
+
+// ---------------------------------------------------------------------------
+// Artifact versioning types
+// ---------------------------------------------------------------------------
+
+type ArtifactVersion = {
+  id: string;
+  content: string;
+  createdAt: string;
+  source: "generated" | "ai-edit" | "manual-edit";
+  editInstruction?: string;
+};
+
+type ArtifactRecord = {
+  type: ArtifactType;
+  currentVersionIndex: number; // pointer into versions[]
+  versions: ArtifactVersion[]; // oldest-first, capped at MAX_VERSIONS
+};
+
+const MAX_VERSIONS = 20;
+
+function makeVersion(
+  content: string,
+  source: ArtifactVersion["source"],
+  instruction?: string,
+): ArtifactVersion {
+  return {
+    id: crypto.randomUUID(),
+    content,
+    createdAt: new Date().toISOString(),
+    source,
+    editInstruction: instruction,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store shape
+// ---------------------------------------------------------------------------
+
+type ArtifactKey =
+  | "causal-graph"
+  | "statistical-model"
+  | "property-tests"
+  | "balanced-perspectives"
+  | "counterexamples";
+
+interface WorkspaceState {
+  // --- Source inputs ---
+  sourceText: string;
+  extractedFiles: { name: string; text: string }[];
+  contextText: string;
+
+  // --- Deductive artifacts (legacy flat fields, kept for pipeline compat) ---
+  semiformalText: string;
+  leanCode: string;
+  semiformalDirty: boolean;
+  verificationStatus: VerificationStatus;
+  verificationErrors: string;
+
+  // --- Structured artifacts (with versioning) ---
+  artifacts: Partial<Record<ArtifactKey, ArtifactRecord>>;
+
+  // --- Decomposition ---
+  decomposition: PersistedDecomposition;
+}
+
+interface WorkspaceActions {
+  // Simple setters
+  setSourceText: (v: string) => void;
+  setExtractedFiles: (v: { name: string; text: string }[]) => void;
+  setContextText: (v: string) => void;
+  setSemiformalText: (v: string | ((prev: string) => string)) => void;
+  setLeanCode: (v: string | ((prev: string) => string)) => void;
+  setSemiformalDirty: (v: boolean) => void;
+  setVerificationStatus: (v: VerificationStatus) => void;
+  setVerificationErrors: (v: string) => void;
+
+  // Artifact versioning
+  setArtifactGenerated: (key: ArtifactKey, content: string) => void;
+  setArtifactEdited: (key: ArtifactKey, content: string, source: "ai-edit" | "manual-edit", instruction?: string) => void;
+  undoArtifact: (key: ArtifactKey) => void;
+  redoArtifact: (key: ArtifactKey) => void;
+  getArtifactContent: (key: ArtifactKey) => string | null;
+  canUndo: (key: ArtifactKey) => boolean;
+  canRedo: (key: ArtifactKey) => boolean;
+
+  // Decomposition
+  setDecomposition: (d: PersistedDecomposition) => void;
+
+  // Snapshot/restore (for workspace sessions)
+  getSnapshot: () => WorkspaceState;
+  resetToSnapshot: (data: WorkspaceState) => void;
+  clearWorkspace: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Default state
+// ---------------------------------------------------------------------------
+
+const DEFAULT_STATE: WorkspaceState = {
+  sourceText: "",
+  extractedFiles: [],
+  contextText: "",
+  semiformalText: "",
+  leanCode: "",
+  semiformalDirty: false,
+  verificationStatus: "none",
+  verificationErrors: "",
+  artifacts: {},
+  decomposition: {
+    nodes: [],
+    selectedNodeId: null,
+    paperText: "",
+    sources: [],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export const useWorkspaceStore = create<WorkspaceState & WorkspaceActions>()(
+  persist(
+    (set, get) => ({
+      ...DEFAULT_STATE,
+
+      // --- Simple setters ---
+      setSourceText: (v) => set({ sourceText: v }),
+      setExtractedFiles: (v) => set({ extractedFiles: v }),
+      setContextText: (v) => set({ contextText: v }),
+      setSemiformalText: (v) =>
+        set((s) => ({
+          semiformalText: typeof v === "function" ? v(s.semiformalText) : v,
+        })),
+      setLeanCode: (v) =>
+        set((s) => ({
+          leanCode: typeof v === "function" ? v(s.leanCode) : v,
+        })),
+      setSemiformalDirty: (v) => set({ semiformalDirty: v }),
+      setVerificationStatus: (v) => set({ verificationStatus: v }),
+      setVerificationErrors: (v) => set({ verificationErrors: v }),
+
+      // --- Artifact versioning ---
+      setArtifactGenerated: (key, content) =>
+        set((s) => {
+          const existing = s.artifacts[key];
+          const version = makeVersion(content, "generated");
+          const versions = existing
+            ? [...existing.versions.slice(-MAX_VERSIONS + 1), version]
+            : [version];
+          return {
+            artifacts: {
+              ...s.artifacts,
+              [key]: {
+                type: key,
+                currentVersionIndex: versions.length - 1,
+                versions,
+              },
+            },
+          };
+        }),
+
+      setArtifactEdited: (key, content, source, instruction) =>
+        set((s) => {
+          const existing = s.artifacts[key];
+          if (!existing) {
+            // No existing record — create one with this edit as first version
+            const version = makeVersion(content, source, instruction);
+            return {
+              artifacts: {
+                ...s.artifacts,
+                [key]: { type: key, currentVersionIndex: 0, versions: [version] },
+              },
+            };
+          }
+          // Truncate any "future" versions (redo history) when making a new edit
+          const version = makeVersion(content, source, instruction);
+          const truncated = existing.versions.slice(0, existing.currentVersionIndex + 1);
+          const versions = [...truncated.slice(-MAX_VERSIONS + 1), version];
+          return {
+            artifacts: {
+              ...s.artifacts,
+              [key]: {
+                type: key,
+                currentVersionIndex: versions.length - 1,
+                versions,
+              },
+            },
+          };
+        }),
+
+      undoArtifact: (key) =>
+        set((s) => {
+          const rec = s.artifacts[key];
+          if (!rec || rec.currentVersionIndex <= 0) return s;
+          return {
+            artifacts: {
+              ...s.artifacts,
+              [key]: { ...rec, currentVersionIndex: rec.currentVersionIndex - 1 },
+            },
+          };
+        }),
+
+      redoArtifact: (key) =>
+        set((s) => {
+          const rec = s.artifacts[key];
+          if (!rec || rec.currentVersionIndex >= rec.versions.length - 1) return s;
+          return {
+            artifacts: {
+              ...s.artifacts,
+              [key]: { ...rec, currentVersionIndex: rec.currentVersionIndex + 1 },
+            },
+          };
+        }),
+
+      getArtifactContent: (key) => {
+        const rec = get().artifacts[key];
+        if (!rec) return null;
+        return rec.versions[rec.currentVersionIndex]?.content ?? null;
+      },
+
+      canUndo: (key) => {
+        const rec = get().artifacts[key];
+        return !!rec && rec.currentVersionIndex > 0;
+      },
+
+      canRedo: (key) => {
+        const rec = get().artifacts[key];
+        return !!rec && rec.currentVersionIndex < rec.versions.length - 1;
+      },
+
+      // --- Decomposition ---
+      setDecomposition: (d) => set({ decomposition: d }),
+
+      // --- Snapshot/restore ---
+      getSnapshot: () => {
+        const s = get();
+        return {
+          sourceText: s.sourceText,
+          extractedFiles: s.extractedFiles.map(({ name, text }) => ({ name, text })),
+          contextText: s.contextText,
+          semiformalText: s.semiformalText,
+          leanCode: s.leanCode,
+          semiformalDirty: s.semiformalDirty,
+          verificationStatus: s.verificationStatus,
+          verificationErrors: s.verificationErrors,
+          artifacts: structuredClone(s.artifacts),
+          decomposition: structuredClone(s.decomposition),
+        };
+      },
+
+      resetToSnapshot: (data) => set({ ...data }),
+
+      clearWorkspace: () => set({ ...DEFAULT_STATE }),
+    }),
+    {
+      name: "workspace-zustand-v1", // localStorage key
+      storage: createJSONStorage(() => localStorage),
+      // skipHydration: true — SSR safe. Call rehydrate() in a useEffect.
+      skipHydration: true,
+      // Only persist data, not actions
+      partialize: (state) => ({
+        sourceText: state.sourceText,
+        extractedFiles: state.extractedFiles,
+        contextText: state.contextText,
+        semiformalText: state.semiformalText,
+        leanCode: state.leanCode,
+        semiformalDirty: state.semiformalDirty,
+        verificationStatus: state.verificationStatus,
+        verificationErrors: state.verificationErrors,
+        artifacts: state.artifacts,
+        decomposition: state.decomposition,
+      }),
+    },
+  ),
+);

--- a/app/lib/types/artifactStore.ts
+++ b/app/lib/types/artifactStore.ts
@@ -1,0 +1,37 @@
+/**
+ * Types for the artifact versioning layer in the Zustand workspace store.
+ *
+ * Each structured artifact (causal-graph, statistical-model, etc.) is stored
+ * as an ArtifactRecord with a version history. This enables undo/redo and
+ * preserves user edits across regeneration cycles.
+ */
+
+import type { ArtifactType } from "./session";
+
+/** Subset of ArtifactType that uses structured JSON and the versioned store.
+ *  Semiformal and lean are stored as flat string fields for pipeline compatibility. */
+export type ArtifactKey = Exclude<ArtifactType, "semiformal" | "lean">;
+
+export type ArtifactVersion = {
+  id: string;
+  content: string;
+  createdAt: string;
+  source: "generated" | "ai-edit" | "manual-edit";
+  editInstruction?: string;
+};
+
+export type ArtifactRecord = {
+  type: ArtifactKey;
+  currentVersionIndex: number; // pointer into versions[]
+  versions: ArtifactVersion[]; // oldest-first, capped at MAX_VERSIONS
+};
+
+/** Provenance tracks which inputs produced a given artifact version.
+ *  Used for staleness detection (Phase 3). */
+export type GenerationProvenance = {
+  sourceHash: string;
+  contextHash: string;
+  generatedAt: string;
+};
+
+export const MAX_VERSIONS = 20;

--- a/docs/decisions/005-zustand-state-management.md
+++ b/docs/decisions/005-zustand-state-management.md
@@ -1,0 +1,40 @@
+# 005: Zustand for State Management
+
+## Context
+
+The app's state management outgrew its `useState` sprawl in `page.tsx` (~20+ variables). Symptoms: ref-based accessor hacks to avoid stale closures, manual debounced localStorage persistence, no artifact edit history, no undo/redo. Upcoming features (graph editing, provenance tracking, import/export) would worsen the complexity.
+
+## Options Considered
+
+12 candidate architectures evaluated via divergent design:
+- **Do nothing / minimal patches** — cheapest but worsens sprawl
+- **Artifact Store (custom)** — additive layer, no deps, but creates two sources of truth
+- **Zustand** — well-known library, already a transitive dep via ReactFlow
+- **Event-sourced / CRDT / SQLite** — powerful but poor incremental adoption
+- **useReducer / Context providers** — partial solutions, don't address core problems
+
+## Decision
+
+**Zustand v5 with artifact versioning layer.** Validated via spike (20 tests, all passing).
+
+## Rationale
+
+- `persist` middleware replaces manual debounce/localStorage/`buildSaveInput` pattern
+- `getState()` eliminates stale-closure ref hacks in `PipelineAccessors`
+- Artifact versioning (undo/redo) is a natural fit as store state
+- `skipHydration: true` + `rehydrate()` handles Next.js SSR
+- ReactFlow already bundles zustand@4 — adding v5 is barely a new dependency
+- Well-documented library reduces bus-factor risk vs custom abstractions
+
+## Consequences
+
+**Easier:**
+- Adding new state fields (just add to store, no useState/useCallback boilerplate)
+- Edit history / undo / redo
+- Snapshot/restore for sessions
+- Eliminating stale closures in async callbacks
+
+**Harder:**
+- Streaming previews must stay outside persisted store (persist writes on every set())
+- Every component reading state via props must be migrated to selectors (incremental)
+- New dependency to understand (though well-known in React ecosystem)

--- a/docs/spikes/zustand-state-management.md
+++ b/docs/spikes/zustand-state-management.md
@@ -1,0 +1,63 @@
+# Spike: Can Zustand replace the useState sprawl in page.tsx incrementally while preserving streaming previews, ref-based accessors, and localStorage persistence?
+
+Date: 2026-04-02
+Last verified: 2026-04-02
+Relevant paths: app/page.tsx, app/hooks/useWorkspacePersistence.ts, app/hooks/useFormalizationPipeline.ts, app/hooks/useStreamingMerge.ts
+Branch: spike/zustand-state-management-2026-04-02 (can be deleted)
+Time spent: ~20 minutes
+
+## Answer
+
+Yes. Zustand v5 handles all integration points cleanly. The `persist` middleware replaces the manual debounce/localStorage logic. The `getState()` pattern eliminates the stale-closure ref hacks used by `useFormalizationPipeline`. Artifact versioning (undo/redo/edit history) works as a thin layer within the store. SSR hydration is handled via `skipHydration: true` + `rehydrate()` in a useEffect.
+
+## Key findings
+
+### What worked
+- **persist middleware** replaces the entire `scheduleSave`/`flushSave`/`buildSaveInput` pattern in `useWorkspacePersistence.ts`. `partialize` keeps functions out of localStorage. `skipHydration` is SSR-safe.
+- **Artifact versioning** as a simple `versions[]` + `currentVersionIndex` within the store. Undo/redo = index navigation. Truncate redo history on new edits. Cap at 20 versions. All tested and working.
+- **PipelineAccessors pattern** maps cleanly: `getSemiformal: () => useWorkspaceStore.getState().semiformalText`. No refs needed — `getState()` always returns fresh state by design.
+- **Migration from workspace-v2** is straightforward: read old data, call setters. Tested in spike.
+- **Snapshot/restore** (for workspace sessions): `getSnapshot()` returns a deep copy, `resetToSnapshot()` sets all state at once. Same API surface as current `useWorkspacePersistence`.
+- **Selective re-renders**: React components use `useWorkspaceStore((s) => s.sourceText)` — only re-renders when that specific field changes. No `useMemo` wrappers needed.
+- **Streaming previews**: The `useStreamingMerge` hook doesn't need to change. Streaming state can stay in local component state (or a separate transient store). The Zustand store holds final/persisted data only.
+
+### What didn't (or required adjustment)
+- **Zustand v5 changed `subscribe` API**: Selector-based subscribe (for vanilla JS, not React) requires `subscribeWithSelector` middleware. Not an issue for React components which use `useStore(selector)` instead.
+- **ReactFlow already bundles zustand@4.x internally**: npm nests the versions, so no conflict. But it means zustand is already a transitive dependency — adding it top-level barely changes the dep footprint.
+
+### Surprises or gotchas
+- **persist middleware saves synchronously on every `set()` call** by default. During streaming (50ms throttled token callbacks), this would write to localStorage on every token. Solutions: (a) use a custom `storage` adapter with debouncing, (b) keep streaming state outside the persisted store (recommended — streaming is transient).
+- **`partialize` is essential**: Without it, Zustand tries to serialize the action functions to localStorage, which fails silently or produces bloated JSON.
+- The `functional update` pattern (`setSemiformalText((prev) => prev + "...")`) works natively in Zustand's `set()` — it reads the current state from the updater function argument.
+
+## Recommendation
+
+Proceed to RPI. Zustand is a clear win for this codebase.
+
+## RPI seed
+
+- **Scope for RPI**: Replace `useWorkspacePersistence` and the ~20 useState variables in `page.tsx` with a Zustand store, adding artifact versioning (edit history/undo/redo), while preserving all existing functionality.
+- **Known invariants**:
+  - Streaming preview state must NOT go through the persisted store (too frequent writes). Keep it in local state or a separate non-persisted store.
+  - `skipHydration: true` + `rehydrate()` in useEffect is required for Next.js SSR safety.
+  - `partialize` must exclude all action functions from persistence.
+  - `PipelineAccessors` should use `getState()` (not selectors) to always read fresh state in async callbacks.
+  - Decomposition state is currently separately managed by `useDecomposition` and synced to persistence — this pattern can continue, with the Zustand store as the sync target.
+- **Relevant files/APIs**:
+  - `app/page.tsx` (lines 62-265): All state declarations and wiring
+  - `app/hooks/useWorkspacePersistence.ts`: The hook being replaced
+  - `app/hooks/useFormalizationPipeline.ts`: Uses PipelineAccessors pattern (lines 16-32)
+  - `app/hooks/useStreamingMerge.ts`: Stays unchanged
+  - `app/hooks/useArtifactEditing.ts`: Will use store's `setArtifactEdited` instead of raw setter
+  - `app/hooks/useWorkspaceSessions.ts`: Uses `getSnapshot`/`resetToSnapshot` — same API from Zustand store
+  - `app/lib/utils/workspacePersistence.ts`: Migration from workspace-v2 data
+- **Gotchas to carry forward**:
+  - Zustand's persist middleware saves on every `set()` — debounce or exclude transient state.
+  - ReactFlow uses zustand@4 internally; our zustand@5 is fine but be aware if debugging store-related issues in ReactFlow.
+  - Version history cap (20) is important for localStorage size. Consider also adding a total-size check with fallback to trimming oldest versions.
+  - The `flushSave()` pattern (used after generation completes) is handled naturally by persist middleware — but if debouncing is added, need an explicit flush mechanism.
+- **What the spike did NOT answer**:
+  - Exact migration strategy for `useWorkspaceSessions` (workspace-level sessions that snapshot everything). The snapshot/restore API is compatible, but the dual-store (formalization sessions + workspace sessions) needs design work.
+  - How to handle the decomposition store (separate Zustand store? slice of the workspace store?). The spike only tested workspace state.
+  - Performance impact of the persist middleware on large workspaces (many nodes with artifact history). May need IndexedDB as a future optimization.
+  - How `useFormalizationSessions` (the per-run session history) should interact with the artifact store's version history — potential duplication.

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,35 +89,57 @@
       }
     },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
-      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-color-parser": "^4.0.2",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
-      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.3.tgz",
+      "integrity": "sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
@@ -196,6 +218,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
@@ -230,14 +262,14 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -313,23 +345,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -343,9 +375,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -433,9 +465,9 @@
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
-      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
       "dev": true,
       "funding": [
         {
@@ -457,9 +489,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
-      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
       "dev": true,
       "funding": [
         {
@@ -474,7 +506,7 @@
       "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.2.0"
+        "@csstools/css-calc": "^3.1.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -508,9 +540,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
-      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
+      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
       "dev": true,
       "funding": [
         {
@@ -553,21 +585,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.1.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -575,9 +607,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -628,13 +660,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
-      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "version": "0.23.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
+      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.5",
+        "@eslint/object-schema": "^3.0.3",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
@@ -643,22 +675,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
-      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
+      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1"
+        "@eslint/core": "^1.1.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
+      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -669,9 +701,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
-      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
+      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -679,13 +711,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
+      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.2.1",
+        "@eslint/core": "^1.1.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -763,9 +795,9 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -855,9 +887,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -873,9 +902,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -893,9 +919,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -911,9 +934,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -931,9 +951,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -949,9 +966,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -969,9 +983,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -988,9 +999,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1006,9 +1014,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1032,9 +1037,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1056,9 +1058,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1082,9 +1081,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1106,9 +1102,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1132,9 +1125,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1157,9 +1147,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1181,9 +1168,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1592,22 +1576,16 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
       }
     },
     "node_modules/@next/env": {
@@ -1617,9 +1595,9 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.3.tgz",
-      "integrity": "sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
+      "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1814,10 +1792,20 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/runtime": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
+      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
+      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2095,9 +2083,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
       "cpu": [
         "arm64"
       ],
@@ -2112,9 +2100,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
       "cpu": [
         "arm64"
       ],
@@ -2129,9 +2117,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
       "cpu": [
         "x64"
       ],
@@ -2146,9 +2134,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
       "cpu": [
         "x64"
       ],
@@ -2163,9 +2151,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
+      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
       "cpu": [
         "arm"
       ],
@@ -2180,16 +2168,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2200,16 +2185,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2220,16 +2202,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2240,16 +2219,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2260,16 +2236,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
+      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2280,16 +2253,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
+      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2300,9 +2270,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
+      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
       "cpu": [
         "arm64"
       ],
@@ -2317,9 +2287,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
+      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
       "cpu": [
         "wasm32"
       ],
@@ -2327,18 +2297,33 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@napi-rs/wasm-runtime": "^1.1.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
       "cpu": [
         "arm64"
       ],
@@ -2353,9 +2338,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
+      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
       "cpu": [
         "x64"
       ],
@@ -2400,49 +2385,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
-      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
+      "integrity": "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "enhanced-resolve": "^5.19.0",
         "jiti": "^2.6.1",
-        "lightningcss": "1.32.0",
+        "lightningcss": "1.31.1",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.2"
+        "tailwindcss": "4.2.1"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
-      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.1.tgz",
+      "integrity": "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-x64": "4.2.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+        "@tailwindcss/oxide-android-arm64": "4.2.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.1",
+        "@tailwindcss/oxide-darwin-x64": "4.2.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.1"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
-      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.1.tgz",
+      "integrity": "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==",
       "cpu": [
         "arm64"
       ],
@@ -2457,9 +2442,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
-      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.1.tgz",
+      "integrity": "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==",
       "cpu": [
         "arm64"
       ],
@@ -2474,9 +2459,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
-      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.1.tgz",
+      "integrity": "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==",
       "cpu": [
         "x64"
       ],
@@ -2491,9 +2476,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
-      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.1.tgz",
+      "integrity": "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==",
       "cpu": [
         "x64"
       ],
@@ -2508,9 +2493,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
-      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.1.tgz",
+      "integrity": "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==",
       "cpu": [
         "arm"
       ],
@@ -2525,16 +2510,13 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
-      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.1.tgz",
+      "integrity": "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2545,16 +2527,13 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
-      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.1.tgz",
+      "integrity": "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2565,16 +2544,13 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
-      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz",
+      "integrity": "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2585,16 +2561,13 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
-      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.1.tgz",
+      "integrity": "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2605,9 +2578,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
-      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.1.tgz",
+      "integrity": "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -2634,10 +2607,74 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
-      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
+      "integrity": "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==",
       "cpu": [
         "arm64"
       ],
@@ -2652,9 +2689,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
-      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.1.tgz",
+      "integrity": "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==",
       "cpu": [
         "x64"
       ],
@@ -2669,17 +2706,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.2.tgz",
-      "integrity": "sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.1.tgz",
+      "integrity": "sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.2.2",
-        "@tailwindcss/oxide": "4.2.2",
+        "@tailwindcss/node": "4.2.1",
+        "@tailwindcss/oxide": "4.2.1",
         "postcss": "^8.5.6",
-        "tailwindcss": "4.2.2"
+        "tailwindcss": "4.2.1"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -2713,6 +2750,17 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -3074,9 +3122,9 @@
       "license": "MIT"
     },
     "node_modules/@types/debug": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
-      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -3208,20 +3256,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/type-utils": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.5.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3231,9 +3279,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/parser": "^8.56.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -3247,16 +3295,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3268,18 +3316,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -3290,18 +3338,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3312,9 +3360,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3325,21 +3373,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.5.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3350,13 +3398,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3368,21 +3416,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.5.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3392,33 +3440,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3429,17 +3467,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.56.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -3562,9 +3600,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3579,9 +3614,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3596,9 +3628,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3613,9 +3642,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3630,9 +3656,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3647,9 +3670,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3664,9 +3684,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3681,9 +3698,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3705,19 +3719,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
@@ -3789,31 +3790,31 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
         "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.0",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3822,7 +3823,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -3834,26 +3835,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.1.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.0",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3861,14 +3862,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3877,9 +3878,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3887,24 +3888,24 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.0",
         "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3961,37 +3962,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
       "dev": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -4198,9 +4176,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -4258,9 +4236,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
-      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz",
+      "integrity": "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4286,9 +4264,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4312,9 +4290,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -4332,11 +4310,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4346,15 +4324,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -4396,9 +4374,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+      "version": "1.0.30001766",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001766.tgz",
+      "integrity": "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4934,9 +4912,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.336",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
-      "integrity": "sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==",
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
     },
@@ -4948,9 +4926,9 @@
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4974,9 +4952,9 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
-      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5063,16 +5041,16 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
-      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
+      "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.9",
+        "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.2",
+        "es-abstract": "^1.24.1",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
@@ -5084,7 +5062,7 @@
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
         "iterator.prototype": "^1.1.5",
-        "math-intrinsics": "^1.1.0"
+        "safe-array-concat": "^1.1.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5181,18 +5159,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
-      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
+      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.4",
-        "@eslint/config-helpers": "^0.5.4",
-        "@eslint/core": "^1.2.0",
-        "@eslint/plugin-kit": "^0.7.0",
+        "@eslint/config-array": "^0.23.3",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.1",
+        "@eslint/plugin-kit": "^0.6.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -5203,7 +5181,7 @@
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^9.1.2",
         "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.2.0",
+        "espree": "^11.1.1",
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -5237,13 +5215,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.3.tgz",
-      "integrity": "sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.6.tgz",
+      "integrity": "sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.3",
+        "@next/eslint-plugin-next": "16.1.6",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -5263,16 +5241,6 @@
         }
       }
     },
-    "node_modules/eslint-config-next/node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/eslint-config-next/node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5281,9 +5249,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-config-next/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5466,16 +5434,50 @@
         "node": "*"
       }
     },
+    "node_modules/eslint-config-next/node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
-      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
-        "is-core-module": "^2.16.1",
-        "resolve": "^2.0.0-next.6"
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -5923,9 +5925,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6485,19 +6487,6 @@
         "semver": "^7.7.1"
       }
     },
-    "node_modules/is-bun-module/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -6859,9 +6848,10 @@
       }
     },
     "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -6907,14 +6897,14 @@
       "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
-      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.0.tgz",
+      "integrity": "sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.5",
-        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.2",
         "@bramus/specificity": "^2.4.2",
         "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
         "@exodus/bytes": "^1.15.0",
@@ -6928,7 +6918,7 @@
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^6.0.1",
-        "undici": "^7.24.5",
+        "undici": "^7.24.3",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
@@ -6945,6 +6935,16 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -7105,9 +7105,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
+      "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -7121,23 +7121,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.31.1",
+        "lightningcss-darwin-arm64": "1.31.1",
+        "lightningcss-darwin-x64": "1.31.1",
+        "lightningcss-freebsd-x64": "1.31.1",
+        "lightningcss-linux-arm-gnueabihf": "1.31.1",
+        "lightningcss-linux-arm64-gnu": "1.31.1",
+        "lightningcss-linux-arm64-musl": "1.31.1",
+        "lightningcss-linux-x64-gnu": "1.31.1",
+        "lightningcss-linux-x64-musl": "1.31.1",
+        "lightningcss-win32-arm64-msvc": "1.31.1",
+        "lightningcss-win32-x64-msvc": "1.31.1"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
+      "integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
       "cpu": [
         "arm64"
       ],
@@ -7156,9 +7156,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
+      "integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
       "cpu": [
         "arm64"
       ],
@@ -7177,9 +7177,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
+      "integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
       "cpu": [
         "x64"
       ],
@@ -7198,9 +7198,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
+      "integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
       "cpu": [
         "x64"
       ],
@@ -7219,9 +7219,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
+      "integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
       "cpu": [
         "arm"
       ],
@@ -7240,16 +7240,13 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
+      "integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7264,16 +7261,13 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
+      "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7288,16 +7282,13 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
+      "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7312,16 +7303,13 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
+      "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7336,9 +7324,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
+      "integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
       "cpu": [
         "arm64"
       ],
@@ -7357,9 +7345,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
+      "integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
       "cpu": [
         "x64"
       ],
@@ -7394,9 +7382,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/longest-streak": {
@@ -7434,13 +7422,13 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lz-string": {
@@ -7486,6 +7474,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/mammoth/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/markdown-table": {
@@ -8433,13 +8430,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -8605,6 +8602,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/node-readable-to-web-readable-stream": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
@@ -8613,9 +8620,9 @@
       "optional": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -8940,9 +8947,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8963,9 +8970,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -9030,6 +9037,28 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -9047,13 +9076,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -9118,12 +9140,11 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -9184,6 +9205,12 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -9355,16 +9382,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -9400,14 +9424,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
+      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.115.0",
+        "@rolldown/pluginutils": "1.0.0-rc.9"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -9416,27 +9440,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
+      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9484,13 +9508,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-array-concat/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -9513,13 +9530,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safe-push-apply/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
@@ -9559,13 +9569,16 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/set-function-length": {
@@ -9668,19 +9681,6 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -9725,14 +9725,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
-      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.4"
+        "object-inspect": "^1.13.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10068,15 +10068,15 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
+      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10095,9 +10095,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10105,14 +10105,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
+        "picomatch": "^4.0.3"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -10140,9 +10140,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10163,22 +10163,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.26.tgz",
+      "integrity": "sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.28"
+        "tldts-core": "^7.0.26"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.26.tgz",
+      "integrity": "sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==",
       "dev": true,
       "license": "MIT"
     },
@@ -10248,9 +10248,9 @@
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10385,16 +10385,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
-      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
+      "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.2",
-        "@typescript-eslint/parser": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2"
+        "@typescript-eslint/eslint-plugin": "8.56.1",
+        "@typescript-eslint/parser": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10405,7 +10405,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -10434,9 +10434,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10699,16 +10699,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
+      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
+        "picomatch": "^4.0.3",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
+        "rolldown": "1.0.0-rc.9",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -10725,8 +10726,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
+        "@vitejs/devtools": "^0.0.0-alpha.31",
+        "esbuild": "^0.27.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -10776,10 +10777,271 @@
         }
       }
     },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10790,19 +11052,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -10813,8 +11075,8 @@
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -10830,15 +11092,13 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -10859,12 +11119,6 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
         "@vitest/ui": {
           "optional": true
         },
@@ -10880,9 +11134,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11013,13 +11267,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/which-builtin-type/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/which-collection": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "reactflow": "^11.11.4",
     "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
-    "remark-math": "^6.0.0"
+    "remark-math": "^6.0.0",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary

- **Zustand workspace store** (`app/lib/stores/workspaceStore.ts`): Replaces the manual `useState` + debounced localStorage pattern with Zustand v5's `persist` middleware. Includes artifact versioning (undo/redo with 20-version cap), snapshot/restore for workspace sessions, and SSR-safe hydration via `skipHydration: true`.
- **Artifact types** (`app/lib/types/artifactStore.ts`): Extracted `ArtifactVersion`, `ArtifactRecord`, `ArtifactKey` (derived from `ArtifactType` excluding semiformal/lean), `GenerationProvenance` (for Phase 3 staleness detection).
- **Compatibility shim** (`app/hooks/useWorkspacePersistence.ts`): Rewritten to delegate to the Zustand store while preserving the exact return API. All existing consumers (`page.tsx`, panels, hooks) work with zero changes.
- **Auto-migration**: `migrateFromV2()` reads old `workspace-v2` localStorage data and populates the versioned store on first load.

This is PR 1 of the [Backend State Management Overhaul plan](../docs/decisions/005-zustand-state-management.md) — foundation only, no consumer changes.

## What changed

| File | Change |
|------|--------|
| `app/lib/types/artifactStore.ts` | **New** — types for versioned artifact store |
| `app/lib/stores/workspaceStore.ts` | Promoted from spike: fixed ArtifactKey (`dialectical-map`), added `migrateFromV2()`, functional updater for `setSemiformalDirty`, exported interfaces |
| `app/hooks/useWorkspacePersistence.ts` | Rewritten as compatibility shim over Zustand store |
| `app/hooks/useWorkspacePersistence.test.ts` | Updated for Zustand-backed persistence |
| `app/lib/stores/__tests__/workspaceStore.test.ts` | Production test suite (versioning, snapshots, pipeline compat) |
| `app/lib/stores/__tests__/workspaceStore-hydration.test.ts` | SSR hydration + workspace-v2 migration tests |

## Test plan

- [x] All 178 tests pass (`npm test`)
- [x] Lint clean (`npm run lint`)
- [x] Manual: load app with existing `workspace-v2` data in localStorage → verify auto-migration populates Zustand store
- [x] Manual: verify all panels render correctly (no regressions from shim)
- [x] Manual: verify state persists across page refresh (now via `workspace-zustand-v1` key)

## Risks / review focus

- **Compatibility shim fidelity**: The shim maps old flat artifact setters (`setCausalGraph(string)`) to `setArtifactGenerated(key, content)`. If any consumer passes `null` to clear an artifact, the shim silently no-ops (artifact stays). This matches current behavior since artifacts are never explicitly cleared, but worth verifying.
- **Persist middleware writes on every `set()`**: This is fine for user interactions but would be problematic for streaming tokens. Streaming state is already kept outside this store (confirmed in spike).

🤖 Generated with [Claude Code](https://claude.com/claude-code)