### PR TITLE
fix: make browse types modal scrollable on small screens

### DIFF
--- a/app/components/features/artifact-selector/ArtifactTypeModal.tsx
+++ b/app/components/features/artifact-selector/ArtifactTypeModal.tsx
@@ -37,11 +37,11 @@ export default function ArtifactTypeModal({
       onClick={onClose}
     >
       <div
-        className="mx-4 max-w-lg w-full rounded-lg border border-[#DDD9D5] bg-white p-5 shadow-xl"
+        className="mx-4 max-w-lg w-full max-h-[85vh] rounded-lg border border-[#DDD9D5] bg-white p-5 shadow-xl flex flex-col"
         style={{ fontFamily: "var(--font-serif, 'EB Garamond', serif)" }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center justify-between mb-4 flex-shrink-0">
           <h2 className="text-lg font-semibold text-[var(--ink-black)]">
             Choose Formalization Types
           </h2>
@@ -54,7 +54,7 @@ export default function ArtifactTypeModal({
           </button>
         </div>
 
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 overflow-y-auto">
           {SELECTABLE_ARTIFACT_TYPES.map((type) => {
             const meta = ARTIFACT_META[type];
             const isActive = selected.includes(type);


### PR DESCRIPTION
## Summary
- Cap the "Browse types" modal height at 85vh so it doesn't overflow the viewport on smaller screens
- Add `overflow-y-auto` to the artifact type list so users can scroll through all options
- Pin the header with `flex-shrink-0` so the title and close button remain visible while scrolling

## Test plan
- [x] Open the app on a short viewport (e.g. 600px height) or zoom in to 150%+
- [x] Click "Browse types" to open the artifact type modal
- [x] Verify the modal fits within the viewport and the list is scrollable
- [x] Verify the header ("Choose Formalization Types" + close button) stays pinned at the top while scrolling
- [x] Verify Escape key and backdrop click still close the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)