### PR TITLE
fix: UI layout and accessibility audit fixes

### DIFF
--- a/app/components/features/session-banner/SessionBanner.tsx
+++ b/app/components/features/session-banner/SessionBanner.tsx
@@ -65,7 +65,7 @@ export default function SessionBanner({ currentSession, sessions, onSelectSessio
       </button>
 
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-1 min-w-[200px] rounded-md border border-[#DDD9D5] bg-white py-1 shadow-md">
+        <div className="absolute right-0 top-full z-50 mt-1 min-w-[200px] max-h-[50vh] overflow-y-auto rounded-md border border-[#DDD9D5] bg-white py-1 shadow-md">
           {sessions.map((s) => (
             <button
               key={s.id}

--- a/app/components/features/workspace-session/WorkspaceSessionBar.tsx
+++ b/app/components/features/workspace-session/WorkspaceSessionBar.tsx
@@ -149,7 +149,7 @@ export default function WorkspaceSessionBar({
 
         {/* Dropdown */}
         {dropdownOpen && (
-          <div className="absolute left-0 top-full z-50 mt-0.5 w-full min-w-[280px] rounded-b-md border border-t-0 border-[#DDD9D5] bg-white py-1 shadow-md">
+          <div className="absolute left-0 top-full z-50 mt-0.5 w-full min-w-[280px] max-h-[60vh] overflow-y-auto rounded-b-md border border-t-0 border-[#DDD9D5] bg-white py-1 shadow-md">
             {sessions.map((s) => {
               const isActive = s.id === activeSession?.id;
               return (

--- a/app/components/layout/IconRail.tsx
+++ b/app/components/layout/IconRail.tsx
@@ -28,7 +28,7 @@ export default function IconRail({ panels, activePanelId, onSelectPanel, onExpor
       {/* Toggle expand/collapse */}
       <button
         onClick={() => setExpanded((prev) => !prev)}
-        className="flex items-center justify-center border-b border-[#DDD9D5] px-3 py-2 text-[#6B6560] hover:text-[var(--ink-black)] transition-colors"
+        className="flex items-center justify-center border-b border-[#DDD9D5] px-3 py-3 text-[#6B6560] hover:text-[var(--ink-black)] transition-colors"
         aria-label={expanded ? "Collapse sidebar" : "Expand sidebar"}
       >
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">

--- a/app/components/panels/AnalyticsPanel.tsx
+++ b/app/components/panels/AnalyticsPanel.tsx
@@ -58,7 +58,7 @@ export default function AnalyticsPanel({ entries, summary, onClear }: AnalyticsP
 
       <div className="flex min-h-0 flex-1 flex-col overflow-auto p-6">
         {/* Summary cards */}
-        <div className="mb-6 grid grid-cols-4 gap-3">
+        <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
           <SummaryCard label="API Calls" value={String(summary.totalCalls)} />
           <SummaryCard
             label="Total Tokens"

--- a/app/components/panels/ArtifactPanelShell.tsx
+++ b/app/components/panels/ArtifactPanelShell.tsx
@@ -60,7 +60,7 @@ export default function ArtifactPanelShell({
   }
 
   return (
-    <div className="flex h-full flex-col overflow-hidden bg-[var(--ivory-cream)]">
+    <div className="relative flex h-full flex-col overflow-hidden bg-[var(--ivory-cream)]">
       {/* Edit progress banner */}
       {editing && (
         <div className="absolute inset-x-0 top-0 z-40 overflow-hidden bg-[var(--ink-black)] px-4 py-1.5 text-center text-xs text-white/90">

--- a/app/components/panels/CausalGraphPanel.tsx
+++ b/app/components/panels/CausalGraphPanel.tsx
@@ -140,8 +140,8 @@ export default function CausalGraphPanel({
     >
       {hasDisplayData && displayGraph && (
         <div className="flex flex-col h-full">
-          {/* View toggle */}
-          <div className="flex gap-1 mb-3">
+          {/* View toggle — sticky so it doesn't scroll away with graph content */}
+          <div className="sticky top-0 z-10 flex gap-1 mb-3 bg-[var(--ivory-cream)] pb-2">
             <button
               onClick={() => setViewMode("graph")}
               className={`px-3 py-1 text-xs font-medium rounded transition-colors ${

--- a/app/components/panels/NodeDetailPanel.tsx
+++ b/app/components/panels/NodeDetailPanel.tsx
@@ -54,132 +54,134 @@ export default function NodeDetailPanel({
         </span>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col overflow-auto">
-        {/* Node info section */}
-        <div className="flex flex-col gap-4 p-6 pb-2">
-          {/* Source Document */}
-          {node.sourceLabel && (
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {/* Scrollable node info section */}
+        <div className="flex-1 min-h-0 overflow-auto">
+          <div className="flex flex-col gap-4 p-6 pb-2">
+            {/* Source Document */}
+            {node.sourceLabel && (
+              <section>
+                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
+                  Source Document
+                </h3>
+                <div className="rounded-md border border-[#DDD9D5] bg-white px-4 py-2 text-sm text-[var(--ink-black)]">
+                  {node.sourceLabel}
+                </div>
+              </section>
+            )}
+
+            {/* Statement */}
             <section>
               <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
-                Source Document
-              </h3>
-              <div className="rounded-md border border-[#DDD9D5] bg-white px-4 py-2 text-sm text-[var(--ink-black)]">
-                {node.sourceLabel}
-              </div>
-            </section>
-          )}
-
-          {/* Statement */}
-          <section>
-            <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
-              Statement
-            </h3>
-            <div className="rounded-md border border-[#DDD9D5] bg-white px-4 py-3 text-sm leading-relaxed text-[var(--ink-black)]">
-              {node.statement}
-            </div>
-          </section>
-
-          {/* Proof text */}
-          {node.proofText && (
-            <section>
-              <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
-                Proof
+                Statement
               </h3>
               <div className="rounded-md border border-[#DDD9D5] bg-white px-4 py-3 text-sm leading-relaxed text-[var(--ink-black)]">
-                {node.proofText}
+                {node.statement}
               </div>
             </section>
-          )}
 
-          {/* Dependencies */}
-          {dependencies.length > 0 && (
-            <section>
-              <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
-                Dependencies
-              </h3>
-              <div className="flex flex-col gap-1">
-                {dependencies.map((dep) => {
-                  const depStatus = STATUS_LABELS[dep.verificationStatus];
-                  return (
-                    <div key={dep.id} className="flex items-center gap-2 rounded-md border border-[#DDD9D5] bg-white px-3 py-2">
-                      <span
-                        className="h-2 w-2 rounded-full"
-                        style={{ backgroundColor: depStatus.color }}
-                      />
-                      <span className="text-xs font-medium text-[var(--ink-black)]">{dep.label}</span>
-                      <span className="text-[10px] text-[#9A9590]">{depStatus.text}</span>
-                    </div>
-                  );
-                })}
-              </div>
-            </section>
-          )}
+            {/* Proof text */}
+            {node.proofText && (
+              <section>
+                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
+                  Proof
+                </h3>
+                <div className="rounded-md border border-[#DDD9D5] bg-white px-4 py-3 text-sm leading-relaxed text-[var(--ink-black)]">
+                  {node.proofText}
+                </div>
+              </section>
+            )}
 
-          {/* Semiformal proof (if generated) */}
-          {node.semiformalProof && (
-            <section>
-              <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
-                Semiformal Proof
-              </h3>
-              <pre className="rounded-md border border-[#DDD9D5] bg-white px-4 py-3 text-sm leading-relaxed text-[var(--ink-black)] whitespace-pre-wrap">
-                {node.semiformalProof}
-              </pre>
-            </section>
-          )}
+            {/* Dependencies */}
+            {dependencies.length > 0 && (
+              <section>
+                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
+                  Dependencies
+                </h3>
+                <div className="flex flex-col gap-1">
+                  {dependencies.map((dep) => {
+                    const depStatus = STATUS_LABELS[dep.verificationStatus];
+                    return (
+                      <div key={dep.id} className="flex items-center gap-2 rounded-md border border-[#DDD9D5] bg-white px-3 py-2">
+                        <span
+                          className="h-2 w-2 rounded-full"
+                          style={{ backgroundColor: depStatus.color }}
+                        />
+                        <span className="text-xs font-medium text-[var(--ink-black)]">{dep.label}</span>
+                        <span className="text-[10px] text-[#9A9590]">{depStatus.text}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
 
-          {/* Lean code (if generated) */}
-          {node.leanCode && (
-            <section>
-              <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
-                Lean4 Code
-              </h3>
-              <pre className="rounded-md border border-[#DDD9D5] bg-white px-4 py-3 font-mono text-sm leading-relaxed text-[var(--ink-black)] whitespace-pre-wrap">
-                {node.leanCode}
-              </pre>
-            </section>
-          )}
+            {/* Semiformal proof (if generated) */}
+            {node.semiformalProof && (
+              <section>
+                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
+                  Semiformal Proof
+                </h3>
+                <pre className="rounded-md border border-[#DDD9D5] bg-white px-4 py-3 text-sm leading-relaxed text-[var(--ink-black)] whitespace-pre-wrap">
+                  {node.semiformalProof}
+                </pre>
+              </section>
+            )}
 
-          {/* Verification errors */}
-          {node.verificationErrors && (
-            <section>
-              <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-red-800">
-                Verification Errors
-              </h3>
-              <pre className="rounded-md border border-red-300 bg-red-50 px-4 py-3 font-mono text-xs leading-relaxed text-red-700 whitespace-pre-wrap">
-                {node.verificationErrors}
-              </pre>
-            </section>
-          )}
+            {/* Lean code (if generated) */}
+            {node.leanCode && (
+              <section>
+                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
+                  Lean4 Code
+                </h3>
+                <pre className="rounded-md border border-[#DDD9D5] bg-white px-4 py-3 font-mono text-sm leading-relaxed text-[var(--ink-black)] whitespace-pre-wrap">
+                  {node.leanCode}
+                </pre>
+              </section>
+            )}
 
-          {/* Separator between node info and formalization controls */}
-          <div className="border-t border-[#DDD9D5]" />
+            {/* Verification errors */}
+            {node.verificationErrors && (
+              <section>
+                <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-red-800">
+                  Verification Errors
+                </h3>
+                <pre className="rounded-md border border-red-300 bg-red-50 px-4 py-3 font-mono text-xs leading-relaxed text-red-700 whitespace-pre-wrap">
+                  {node.verificationErrors}
+                </pre>
+              </section>
+            )}
+          </div>
         </div>
 
-        {/* Lean generation button (when semiformal exists but lean doesn't) */}
-        {showLeanButton && (
-          <div className="shrink-0 px-4 pb-2">
-            <button
-              type="button"
-              onClick={onGenerateLean}
-              disabled={loading}
-              className="w-full rounded-full bg-[var(--ink-black)] px-6 py-2.5 text-sm font-medium text-white shadow-md transition-shadow duration-200 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[var(--ink-black)] focus:ring-offset-2 focus:ring-offset-[var(--ivory-cream)] disabled:opacity-50"
-            >
-              {loading ? "Generating..." : "Generate Lean4 Code"}
-            </button>
-          </div>
-        )}
+        {/* Docked controls — outside scroll container */}
+        <div className="shrink-0 border-t border-[#DDD9D5]">
+          {/* Lean generation button (when semiformal exists but lean doesn't) */}
+          {showLeanButton && (
+            <div className="px-4 py-2">
+              <button
+                type="button"
+                onClick={onGenerateLean}
+                disabled={loading}
+                className="w-full rounded-full bg-[var(--ink-black)] px-6 py-2.5 text-sm font-medium text-white shadow-md transition-shadow duration-200 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[var(--ink-black)] focus:ring-offset-2 focus:ring-offset-[var(--ivory-cream)] disabled:opacity-50"
+              >
+                {loading ? "Generating..." : "Generate Lean4 Code"}
+              </button>
+            </div>
+          )}
 
-        {/* Formalization controls: per-node context, artifact chips, Formalise button */}
-        <FormalizationControls
-          contextText={node.context}
-          onContextChange={onNodeContextChange}
-          selectedArtifactTypes={node.selectedArtifactTypes}
-          onArtifactTypesChange={onNodeArtifactTypesChange}
-          onGenerate={onFormalise}
-          loading={loading}
-          loadingState={loadingState}
-          contextPlaceholder={globalContextText || "e.g., Explore this in the context of decision theory within game-theoretic settings..."}
-        />
+          {/* Formalization controls: per-node context, artifact chips, Formalise button */}
+          <FormalizationControls
+            contextText={node.context}
+            onContextChange={onNodeContextChange}
+            selectedArtifactTypes={node.selectedArtifactTypes}
+            onArtifactTypesChange={onNodeArtifactTypesChange}
+            onGenerate={onFormalise}
+            loading={loading}
+            loadingState={loadingState}
+            contextPlaceholder={globalContextText || "e.g., Explore this in the context of decision theory within game-theoretic settings..."}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **NodeDetailPanel**: move FormalizationControls + Lean button outside the scroll container so the Formalise button stays visible on long nodes (critical — controls were inaccessible on nodes with substantial content)
- **ArtifactPanelShell**: add `relative` to outer container so any future absolute-positioned children (e.g. edit progress banners) anchor correctly
- **AnalyticsPanel**: responsive summary grid (`grid-cols-2` on mobile, `grid-cols-4` on `sm+`) to prevent card overflow on narrow viewports
- **CausalGraphPanel**: make Graph/Details view toggle `sticky` so it doesn't scroll away with graph content
- **WorkspaceSessionBar**: cap session dropdown at `max-h-[60vh]` with `overflow-y-auto` to prevent unbounded growth
- **SessionBanner**: cap formalization session dropdown at `max-h-[50vh]` with `overflow-y-auto`
- **IconRail**: increase expand/collapse toggle padding (`py-2` → `py-3`) for a larger touch target

## Test plan
- [x] Open a node with long content (statement + proof + semiformal + lean + errors) — verify the Formalise button and context textarea remain visible without scrolling to the bottom
- [x] On a narrow viewport (360px), verify analytics summary cards wrap to 2 columns
- [x] With 10+ workspace sessions, open the session dropdown — verify it scrolls instead of overflowing the viewport
- [x] On CausalGraphPanel with a tall graph, scroll down — verify the Graph/Details toggle stays pinned at the top
- [x] Verify the IconRail expand/collapse chevron is comfortably tappable on touch devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)