### PR TITLE
feat: add side-by-side split view for panels

### DIFF
--- a/app/components/layout/IconRail.tsx
+++ b/app/components/layout/IconRail.tsx
@@ -9,9 +9,15 @@ type IconRailProps = {
   onSelectPanel: (id: PanelId) => void;
   onExportAll?: () => void;
   exportAllDisabled?: boolean;
+  secondaryPanelId?: PanelId | null;
+  onSelectSecondaryPanel?: (id: PanelId) => void;
 };
 
-export default function IconRail({ panels, activePanelId, onSelectPanel, onExportAll, exportAllDisabled }: IconRailProps) {
+export default function IconRail({
+  panels, activePanelId, onSelectPanel,
+  onExportAll, exportAllDisabled,
+  secondaryPanelId, onSelectSecondaryPanel,
+}: IconRailProps) {
   const [expanded, setExpanded] = useState(false);
 
   const visiblePanels = panels.filter((p) => !p.hidden);
@@ -40,7 +46,9 @@ export default function IconRail({ panels, activePanelId, onSelectPanel, onExpor
       </button>
 
       {visiblePanels.map((panel, idx) => {
-        const isActive = panel.id === activePanelId;
+        const isPrimary = panel.id === activePanelId;
+        const isSecondary = panel.id === secondaryPanelId;
+        const isActive = isPrimary || isSecondary;
         const prevPanel = idx > 0 ? visiblePanels[idx - 1] : null;
         const showSeparator = prevPanel && prevPanel.group && panel.group && prevPanel.group !== panel.group;
         return (
@@ -49,8 +57,14 @@ export default function IconRail({ panels, activePanelId, onSelectPanel, onExpor
             <div className="mx-3 my-1 border-t border-[#DDD9D5]" />
           )}
           <button
-            onClick={() => onSelectPanel(panel.id)}
-            title={expanded ? undefined : panel.label}
+            onClick={(e) => {
+              if (e.altKey && onSelectSecondaryPanel) {
+                onSelectSecondaryPanel(panel.id);
+              } else {
+                onSelectPanel(panel.id);
+              }
+            }}
+            title={expanded ? undefined : `${panel.label}${onSelectSecondaryPanel ? " (Alt+click for split view)" : ""}`}
             className={`
               group relative flex items-center gap-3 px-3 py-3 text-left transition-colors
               ${isActive
@@ -58,19 +72,19 @@ export default function IconRail({ panels, activePanelId, onSelectPanel, onExpor
                 : "text-[#6B6560] hover:bg-[var(--rail-hover)] hover:text-[var(--ink-black)]"
               }
             `}
-            aria-current={isActive ? "page" : undefined}
+            aria-current={isPrimary ? "page" : undefined}
           >
-            {/* Active indicator bar */}
-            {isActive && (
+            {isPrimary && (
               <span className="absolute left-0 top-1 bottom-1 w-[3px] rounded-r-full bg-[var(--rail-active)]" />
             )}
+            {isSecondary && !isPrimary && (
+              <span className="absolute right-0 top-1 bottom-1 w-[3px] rounded-l-full bg-[var(--rail-active)] opacity-50" />
+            )}
 
-            {/* Icon — always visible */}
             <span className="flex shrink-0 items-center justify-center w-6 h-6">
               {panel.icon}
             </span>
 
-            {/* Label + status — only when expanded */}
             {expanded && (
               <span className="flex min-w-0 flex-col overflow-hidden">
                 <span className="truncate text-xs font-semibold">{panel.label}</span>

--- a/app/components/layout/PanelShell.tsx
+++ b/app/components/layout/PanelShell.tsx
@@ -1,6 +1,7 @@
-import type { PanelDef, PanelId } from "@/app/lib/types/panels";
+import type { PanelDef, PanelId, SplitConfig } from "@/app/lib/types/panels";
 import IconRail from "@/app/components/layout/IconRail";
 import FocusPane from "@/app/components/layout/FocusPane";
+import SplitPane from "@/app/components/layout/SplitPane";
 
 type PanelShellProps = {
   panels: PanelDef[];
@@ -9,9 +10,13 @@ type PanelShellProps = {
   renderPanel: (id: PanelId) => React.ReactNode;
   onExportAll?: () => void;
   exportAllDisabled?: boolean;
+  split: SplitConfig;
 };
 
-export default function PanelShell({ panels, activePanelId, onSelectPanel, renderPanel, onExportAll, exportAllDisabled }: PanelShellProps) {
+export default function PanelShell({
+  panels, activePanelId, onSelectPanel, renderPanel,
+  onExportAll, exportAllDisabled, split,
+}: PanelShellProps) {
   return (
     <div className="flex min-h-0 flex-1 overflow-hidden bg-[var(--ivory-cream)]">
       <IconRail
@@ -20,11 +25,24 @@ export default function PanelShell({ panels, activePanelId, onSelectPanel, rende
         onSelectPanel={onSelectPanel}
         onExportAll={onExportAll}
         exportAllDisabled={exportAllDisabled}
+        secondaryPanelId={split.secondaryPanelId}
+        onSelectSecondaryPanel={split.onSelectSecondaryPanel}
       />
-      <FocusPane
-        activePanelId={activePanelId}
-        renderPanel={renderPanel}
-      />
+      {split.secondaryPanelId ? (
+        <SplitPane
+          primaryPanelId={activePanelId}
+          secondaryPanelId={split.secondaryPanelId}
+          orientation={split.orientation}
+          renderPanel={renderPanel}
+          onCloseSecondary={split.onCloseSecondary}
+          onToggleOrientation={split.onToggleOrientation}
+        />
+      ) : (
+        <FocusPane
+          activePanelId={activePanelId}
+          renderPanel={renderPanel}
+        />
+      )}
     </div>
   );
 }

--- a/app/components/layout/SplitPane.tsx
+++ b/app/components/layout/SplitPane.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import type { PanelId, SplitOrientation } from "@/app/lib/types/panels";
+import FocusPane from "@/app/components/layout/FocusPane";
+
+type SplitPaneProps = {
+  primaryPanelId: PanelId;
+  secondaryPanelId: PanelId;
+  orientation: SplitOrientation;
+  renderPanel: (id: PanelId) => React.ReactNode;
+  onCloseSecondary: () => void;
+  onToggleOrientation: () => void;
+};
+
+const dividerButtonClass =
+  "flex items-center justify-center w-6 h-6 rounded text-[#6B6560] hover:bg-[var(--rail-hover)] hover:text-[var(--ink-black)] transition-colors";
+
+export default function SplitPane({
+  primaryPanelId,
+  secondaryPanelId,
+  orientation,
+  renderPanel,
+  onCloseSecondary,
+  onToggleOrientation,
+}: SplitPaneProps) {
+  const isHorizontal = orientation === "horizontal";
+
+  return (
+    <div
+      className={`flex min-h-0 min-w-0 flex-1 overflow-hidden ${
+        isHorizontal ? "flex-row" : "flex-col"
+      }`}
+    >
+      <FocusPane activePanelId={primaryPanelId} renderPanel={renderPanel} />
+
+      <div
+        className={`group relative flex shrink-0 items-center justify-center ${
+          isHorizontal ? "w-3 flex-col" : "h-3 flex-row"
+        }`}
+      >
+        <div
+          className={`absolute bg-[var(--border-light)] ${
+            isHorizontal
+              ? "left-1/2 top-0 bottom-0 w-px -translate-x-1/2"
+              : "top-1/2 left-0 right-0 h-px -translate-y-1/2"
+          }`}
+        />
+
+        <div
+          className={`absolute z-10 flex gap-1 rounded bg-[var(--rail-bg)] p-1 shadow-md opacity-0 group-hover:opacity-100 transition-opacity ${
+            isHorizontal ? "flex-col" : "flex-row"
+          }`}
+        >
+          <button
+            onClick={onToggleOrientation}
+            title={isHorizontal ? "Switch to top/bottom split" : "Switch to left/right split"}
+            className={dividerButtonClass}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              {isHorizontal ? (
+                <>
+                  <rect x="1" y="1" width="12" height="5" rx="1" />
+                  <rect x="1" y="8" width="12" height="5" rx="1" />
+                </>
+              ) : (
+                <>
+                  <rect x="1" y="1" width="5" height="12" rx="1" />
+                  <rect x="8" y="1" width="5" height="12" rx="1" />
+                </>
+              )}
+            </svg>
+          </button>
+          <button
+            onClick={onCloseSecondary}
+            title="Close split view"
+            className={dividerButtonClass}
+          >
+            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="3" y1="3" x2="11" y2="11" />
+              <line x1="11" y1="3" x2="3" y2="11" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <FocusPane activePanelId={secondaryPanelId} renderPanel={renderPanel} />
+    </div>
+  );
+}

--- a/app/lib/types/panels.ts
+++ b/app/lib/types/panels.ts
@@ -14,6 +14,16 @@ export type PanelId =
 
 export type PanelGroup = "navigation" | "artifacts" | "meta";
 
+export type SplitOrientation = "horizontal" | "vertical";
+
+export type SplitConfig = {
+  secondaryPanelId: PanelId | null;
+  onSelectSecondaryPanel: (id: PanelId) => void;
+  onCloseSecondary: () => void;
+  orientation: SplitOrientation;
+  onToggleOrientation: () => void;
+};
+
 export type PanelDef = {
   id: PanelId;
   label: string;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
-import type { PanelId } from "@/app/lib/types/panels";
+import type { PanelId, SplitOrientation } from "@/app/lib/types/panels";
 import type { ArtifactType } from "@/app/lib/types/session";
 import type { SourceDocument, NodeArtifact } from "@/app/lib/types/decomposition";
 import type { CausalGraphResponse, StatisticalModelResponse, PropertyTestsResponse, DialecticalMapResponse } from "@/app/lib/types/artifacts";
@@ -62,6 +62,8 @@ function phaseToEndpoint(phase: LoadingPhase): string | null {
 export default function Home() {
   // --- Panel navigation ---
   const [activePanelId, setActivePanelIdRaw] = useState<PanelId>("source");
+  const [secondaryPanelId, setSecondaryPanelIdRaw] = useState<PanelId | null>(null);
+  const [splitOrientation, setSplitOrientation] = useState<SplitOrientation>("horizontal");
 
   // --- Persisted state (survives page refresh) ---
   const {
@@ -121,7 +123,23 @@ export default function Home() {
   const setActivePanelId = useCallback((id: PanelId) => {
     if (id === "analytics") refreshAnalytics();
     setActivePanelIdRaw(id);
+    // Clear secondary if it now matches the new primary
+    setSecondaryPanelIdRaw((prev) => prev === id ? null : prev);
   }, [refreshAnalytics]);
+
+  const setSecondaryPanelId = useCallback((id: PanelId) => {
+    if (id === activePanelId) return;
+    if (id === "analytics") refreshAnalytics();
+    setSecondaryPanelIdRaw(id);
+  }, [activePanelId, refreshAnalytics]);
+
+  const closeSecondaryPanel = useCallback(() => {
+    setSecondaryPanelIdRaw(null);
+  }, []);
+
+  const toggleSplitOrientation = useCallback(() => {
+    setSplitOrientation((prev) => prev === "horizontal" ? "vertical" : "horizontal");
+  }, []);
 
   // Derive per-type loading booleans from artifactLoadingState
   const causalGraphLoading = artifactLoadingState["causal-graph"] === "generating";
@@ -765,6 +783,13 @@ export default function Home() {
         renderPanel={renderPanel}
         onExportAll={handleExportAll}
         exportAllDisabled={!hasExportableContent}
+        split={{
+          secondaryPanelId,
+          onSelectSecondaryPanel: setSecondaryPanelId,
+          onCloseSecondary: closeSecondaryPanel,
+          orientation: splitOrientation,
+          onToggleOrientation: toggleSplitOrientation,
+        }}
       />
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -519,7 +519,15 @@ export default function Home() {
 
   const handleSelectNode = useCallback((id: string) => {
     selectNode(id);
-    setActivePanelId("node-detail");
+    // If we're in split mode with the graph visible, open node-detail in the
+    // secondary panel so the graph stays visible for context.
+    if (secondaryPanelId !== null && activePanelId === "decomposition") {
+      setSecondaryPanelId("node-detail");
+    } else if (secondaryPanelId !== null && secondaryPanelId === "decomposition") {
+      setActivePanelId("node-detail");
+    } else {
+      setActivePanelId("node-detail");
+    }
     // Auto-select the most recent session for this node
     const node = decomp.nodes.find((n) => n.id === id);
     if (node) {
@@ -528,7 +536,7 @@ export default function Home() {
         selectSession(nodeSessions[0].id);
       }
     }
-  }, [selectNode, decomp.nodes, sessionsForScope, selectSession, setActivePanelId]);
+  }, [selectNode, decomp.nodes, sessionsForScope, selectSession, setActivePanelId, secondaryPanelId, activePanelId, setSecondaryPanelId]);
 
   // Resolve dependencies for NodeDetailPanel
   const selectedNodeDeps = useMemo(() => {


### PR DESCRIPTION
## Summary

- **Alt+click** any panel icon in the Icon Rail to open it as a secondary panel alongside the current one
- Divider between panels shows hover controls: toggle orientation (horizontal/vertical) and close split
- Secondary panel gets a subtle right-side indicator bar in the rail; both panels highlight as active
- New `SplitPane` component reuses `FocusPane` for both halves — no layout duplication

## Changes

- `SplitPane.tsx` — new component rendering two FocusPanes with a divider
- `PanelShell.tsx` — accepts `SplitConfig`, conditionally renders SplitPane or FocusPane
- `IconRail.tsx` — Alt+click handler, secondary panel indicator, updated tooltips
- `panels.ts` — `SplitOrientation` and `SplitConfig` types
- `page.tsx` — state management for secondary panel and split orientation

## Known limitations

- Split state is not persisted to localStorage (resets on refresh) — intentional for v1
- No keyboard-only way to open the split view (Alt+click only) — accessibility gap to address in a follow-up
- No tests for `SplitPane` yet

## Test plan

- [x] Click a panel icon normally — behaves as before (single panel view)
- [x] Alt+click a different panel icon — opens split view with both panels visible
- [x] Alt+click the already-active primary panel — no-op (guard works)
- [x] Click a panel normally while in split view — replaces primary, clears secondary if it matches
- [x] Hover the divider — orientation toggle and close buttons appear
- [x] Click orientation toggle — switches between left/right and top/bottom split
- [x] Click close button on divider — returns to single panel view
- [x] Refresh page while in split view — returns to single panel (state not persisted)
- [x] Verify rail shows left-side bar on primary, right-side bar (dimmer) on secondary

🤖 Generated with [Claude Code](https://claude.com/claude-code)