### PR TITLE
feat: evidence grounding with overlap detection (Phases 1-3)

### DIFF
--- a/app/api/evidence-overlap/overlapUtils.test.ts
+++ b/app/api/evidence-overlap/overlapUtils.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect } from "vitest";
+import {
+  partitionPapers,
+  buildRelationsFromRefs,
+  findUnmatchedPairs,
+  derivePaperStatus,
+} from "./overlapUtils";
+import type { EvidenceOverlapRequest } from "@/app/lib/types/evidence";
+
+type OverlapPaper = EvidenceOverlapRequest["papers"][number];
+
+/** Helper to create a minimal paper for testing */
+function makePaper(
+  id: string,
+  opts: {
+    studyType?: string;
+    year?: number | null;
+    abstract?: string | null;
+  } = {},
+): OverlapPaper {
+  return {
+    openAlexId: id,
+    title: `Paper ${id}`,
+    year: opts.year === undefined ? 2020 : opts.year,
+    abstract: opts.abstract === undefined ? "An abstract" : opts.abstract,
+    reliability: opts.studyType
+      ? {
+          score: 0.5,
+          studyType: opts.studyType as OverlapPaper["reliability"] extends { studyType: infer T } ? T : never,
+          rationale: "",
+          redFlags: [],
+        }
+      : null,
+  };
+}
+
+describe("partitionPapers", () => {
+  it("separates reviews from individual studies", () => {
+    const papers = [
+      makePaper("W1", { studyType: "meta-analysis" }),
+      makePaper("W2", { studyType: "rct" }),
+      makePaper("W3", { studyType: "systematic-review" }),
+      makePaper("W4", { studyType: "cohort" }),
+    ];
+    const { reviews, studies } = partitionPapers(papers);
+    expect(reviews.map((r) => r.openAlexId)).toEqual(["W1", "W3"]);
+    expect(studies.map((s) => s.openAlexId)).toEqual(["W2", "W4"]);
+  });
+
+  it("treats papers without reliability scores as studies", () => {
+    const papers = [makePaper("W1"), makePaper("W2", { studyType: "rct" })];
+    const { reviews, studies } = partitionPapers(papers);
+    expect(reviews).toHaveLength(0);
+    expect(studies).toHaveLength(2);
+  });
+
+  it("handles empty input", () => {
+    const { reviews, studies } = partitionPapers([]);
+    expect(reviews).toEqual([]);
+    expect(studies).toEqual([]);
+  });
+});
+
+describe("buildRelationsFromRefs", () => {
+  it("finds studies referenced by a review", () => {
+    const reviews = [makePaper("R1", { studyType: "meta-analysis" })];
+    const studies = [makePaper("S1"), makePaper("S2"), makePaper("S3")];
+    const refsMap = new Map([["R1", ["S1", "S3", "OTHER"]]]);
+
+    const relations = buildRelationsFromRefs(reviews, studies, refsMap);
+    expect(relations).toHaveLength(2);
+    expect(relations[0]).toEqual({
+      reviewId: "R1",
+      studyId: "S1",
+      detectionMethod: "citation-graph",
+      confidence: 1.0,
+    });
+    expect(relations[1].studyId).toBe("S3");
+  });
+
+  it("returns empty when review has no matching references", () => {
+    const reviews = [makePaper("R1", { studyType: "meta-analysis" })];
+    const studies = [makePaper("S1")];
+    const refsMap = new Map([["R1", ["UNRELATED1", "UNRELATED2"]]]);
+
+    const relations = buildRelationsFromRefs(reviews, studies, refsMap);
+    expect(relations).toEqual([]);
+  });
+
+  it("returns empty when refsMap is empty", () => {
+    const reviews = [makePaper("R1", { studyType: "meta-analysis" })];
+    const studies = [makePaper("S1")];
+    const relations = buildRelationsFromRefs(reviews, studies, new Map());
+    expect(relations).toEqual([]);
+  });
+
+  it("handles multiple reviews referencing the same study", () => {
+    const reviews = [
+      makePaper("R1", { studyType: "meta-analysis" }),
+      makePaper("R2", { studyType: "systematic-review" }),
+    ];
+    const studies = [makePaper("S1")];
+    const refsMap = new Map([
+      ["R1", ["S1"]],
+      ["R2", ["S1"]],
+    ]);
+
+    const relations = buildRelationsFromRefs(reviews, studies, refsMap);
+    expect(relations).toHaveLength(2);
+    expect(relations[0].reviewId).toBe("R1");
+    expect(relations[1].reviewId).toBe("R2");
+  });
+});
+
+describe("findUnmatchedPairs", () => {
+  it("excludes already-matched pairs", () => {
+    const reviews = [makePaper("R1", { studyType: "meta-analysis", year: 2022 })];
+    const studies = [makePaper("S1", { year: 2020 }), makePaper("S2", { year: 2020 })];
+    const matched = [
+      { reviewId: "R1", studyId: "S1", detectionMethod: "citation-graph" as const, confidence: 1.0 },
+    ];
+
+    const pairs = findUnmatchedPairs(reviews, studies, matched);
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].study.openAlexId).toBe("S2");
+  });
+
+  it("excludes studies published after the review", () => {
+    const reviews = [makePaper("R1", { studyType: "meta-analysis", year: 2020 })];
+    const studies = [
+      makePaper("S1", { year: 2019 }), // before review — included
+      makePaper("S2", { year: 2020 }), // same year — included
+      makePaper("S3", { year: 2021 }), // after review — excluded
+    ];
+
+    const pairs = findUnmatchedPairs(reviews, studies, []);
+    expect(pairs.map((p) => p.study.openAlexId)).toEqual(["S1", "S2"]);
+  });
+
+  it("excludes pairs where study has no abstract", () => {
+    const reviews = [makePaper("R1", { studyType: "meta-analysis", year: 2022 })];
+    const studies = [makePaper("S1", { year: 2020, abstract: null })];
+
+    const pairs = findUnmatchedPairs(reviews, studies, []);
+    expect(pairs).toEqual([]);
+  });
+
+  it("excludes pairs where review has no abstract", () => {
+    const reviews = [makePaper("R1", { studyType: "meta-analysis", year: 2022, abstract: null })];
+    const studies = [makePaper("S1", { year: 2020 })];
+
+    const pairs = findUnmatchedPairs(reviews, studies, []);
+    expect(pairs).toEqual([]);
+  });
+
+  it("includes pairs when years are null (unknown)", () => {
+    const reviews = [makePaper("R1", { studyType: "meta-analysis", year: null })];
+    const studies = [makePaper("S1", { year: null })];
+
+    const pairs = findUnmatchedPairs(reviews, studies, []);
+    expect(pairs).toHaveLength(1);
+  });
+});
+
+describe("derivePaperStatus", () => {
+  it("assigns correct statuses with reviews and relations", () => {
+    const papers = [
+      makePaper("R1", { studyType: "meta-analysis" }),
+      makePaper("S1", { studyType: "rct" }),
+      makePaper("S2", { studyType: "cohort" }),
+    ];
+    const relations = [
+      { reviewId: "R1", studyId: "S1", detectionMethod: "citation-graph" as const, confidence: 1.0 },
+    ];
+
+    const status = derivePaperStatus(papers, relations);
+    expect(status).toEqual({
+      R1: "review",
+      S1: "subsumed",
+      S2: "novel",
+    });
+  });
+
+  it("returns no-reviews when there are no review papers", () => {
+    const papers = [
+      makePaper("S1", { studyType: "rct" }),
+      makePaper("S2", { studyType: "cohort" }),
+    ];
+
+    const status = derivePaperStatus(papers, []);
+    expect(status).toEqual({
+      S1: "no-reviews",
+      S2: "no-reviews",
+    });
+  });
+
+  it("marks all non-review papers as novel when no relations exist", () => {
+    const papers = [
+      makePaper("R1", { studyType: "meta-analysis" }),
+      makePaper("S1", { studyType: "rct" }),
+    ];
+
+    const status = derivePaperStatus(papers, []);
+    expect(status).toEqual({
+      R1: "review",
+      S1: "novel",
+    });
+  });
+
+  it("handles study subsumed by multiple reviews", () => {
+    const papers = [
+      makePaper("R1", { studyType: "meta-analysis" }),
+      makePaper("R2", { studyType: "systematic-review" }),
+      makePaper("S1", { studyType: "rct" }),
+    ];
+    const relations = [
+      { reviewId: "R1", studyId: "S1", detectionMethod: "citation-graph" as const, confidence: 1.0 },
+      { reviewId: "R2", studyId: "S1", detectionMethod: "llm-fallback" as const, confidence: 0.7 },
+    ];
+
+    const status = derivePaperStatus(papers, relations);
+    expect(status.S1).toBe("subsumed");
+  });
+});

--- a/app/api/evidence-overlap/overlapUtils.test.ts
+++ b/app/api/evidence-overlap/overlapUtils.test.ts
@@ -173,7 +173,7 @@ describe("derivePaperStatus", () => {
       { reviewId: "R1", studyId: "S1", detectionMethod: "citation-graph" as const, confidence: 1.0 },
     ];
 
-    const status = derivePaperStatus(papers, relations);
+    const status = derivePaperStatus(papers, relations, new Set(["R1"]));
     expect(status).toEqual({
       R1: "review",
       S1: "subsumed",
@@ -187,7 +187,7 @@ describe("derivePaperStatus", () => {
       makePaper("S2", { studyType: "cohort" }),
     ];
 
-    const status = derivePaperStatus(papers, []);
+    const status = derivePaperStatus(papers, [], new Set());
     expect(status).toEqual({
       S1: "no-reviews",
       S2: "no-reviews",
@@ -200,7 +200,7 @@ describe("derivePaperStatus", () => {
       makePaper("S1", { studyType: "rct" }),
     ];
 
-    const status = derivePaperStatus(papers, []);
+    const status = derivePaperStatus(papers, [], new Set(["R1"]));
     expect(status).toEqual({
       R1: "review",
       S1: "novel",
@@ -218,7 +218,7 @@ describe("derivePaperStatus", () => {
       { reviewId: "R2", studyId: "S1", detectionMethod: "llm-fallback" as const, confidence: 0.7 },
     ];
 
-    const status = derivePaperStatus(papers, relations);
+    const status = derivePaperStatus(papers, relations, new Set(["R1", "R2"]));
     expect(status.S1).toBe("subsumed");
   });
 });

--- a/app/api/evidence-overlap/overlapUtils.ts
+++ b/app/api/evidence-overlap/overlapUtils.ts
@@ -9,9 +9,9 @@ import type {
   PaperOverlapStatus,
   EvidenceOverlapRequest,
 } from "@/app/lib/types/evidence";
-import { REVIEW_STUDY_TYPES } from "@/app/lib/types/evidence";
+import { isReviewType } from "@/app/lib/types/evidence";
 
-type OverlapPaper = EvidenceOverlapRequest["papers"][number];
+export type OverlapPaper = EvidenceOverlapRequest["papers"][number];
 
 /** Partition papers into reviews (meta-analysis, systematic-review) and studies. */
 export function partitionPapers(papers: OverlapPaper[]): {
@@ -21,8 +21,7 @@ export function partitionPapers(papers: OverlapPaper[]): {
   const reviews: OverlapPaper[] = [];
   const studies: OverlapPaper[] = [];
   for (const p of papers) {
-    const studyType = p.reliability?.studyType;
-    if (studyType && (REVIEW_STUDY_TYPES as readonly string[]).includes(studyType)) {
+    if (isReviewType(p.reliability?.studyType)) {
       reviews.push(p);
     } else {
       studies.push(p);
@@ -100,17 +99,16 @@ export function findUnmatchedPairs(
 
 /** Derive per-paper overlap status from the full set of relations.
  *
- *  - Papers with review study types get "review"
+ *  - Papers whose IDs are in reviewIds get "review"
  *  - Studies that appear in any relation as the studyId get "subsumed"
  *  - Remaining studies get "novel"
- *  - If there are no reviews at all, every paper gets "no-reviews" */
+ *  - If reviewIds is empty, every paper gets "no-reviews" */
 export function derivePaperStatus(
   papers: OverlapPaper[],
   relations: SubsumptionRelation[],
+  reviewIds: Set<string>,
 ): Record<string, PaperOverlapStatus> {
-  const { reviews } = partitionPapers(papers);
-
-  if (reviews.length === 0) {
+  if (reviewIds.size === 0) {
     const status: Record<string, PaperOverlapStatus> = {};
     for (const p of papers) {
       status[p.openAlexId] = "no-reviews";
@@ -118,7 +116,6 @@ export function derivePaperStatus(
     return status;
   }
 
-  const reviewIds = new Set(reviews.map((r) => r.openAlexId));
   const subsumedIds = new Set(relations.map((r) => r.studyId));
 
   const status: Record<string, PaperOverlapStatus> = {};

--- a/app/api/evidence-overlap/overlapUtils.ts
+++ b/app/api/evidence-overlap/overlapUtils.ts
@@ -1,0 +1,135 @@
+/** Pure functions for overlap and subsumption detection.
+ *
+ * These operate on the scored paper data from Phase 2 and OpenAlex
+ * reference lists to build a containment graph between review papers
+ * and individual studies in the same evidence slot. */
+
+import type {
+  SubsumptionRelation,
+  PaperOverlapStatus,
+  EvidenceOverlapRequest,
+} from "@/app/lib/types/evidence";
+import { REVIEW_STUDY_TYPES } from "@/app/lib/types/evidence";
+
+type OverlapPaper = EvidenceOverlapRequest["papers"][number];
+
+/** Partition papers into reviews (meta-analysis, systematic-review) and studies. */
+export function partitionPapers(papers: OverlapPaper[]): {
+  reviews: OverlapPaper[];
+  studies: OverlapPaper[];
+} {
+  const reviews: OverlapPaper[] = [];
+  const studies: OverlapPaper[] = [];
+  for (const p of papers) {
+    const studyType = p.reliability?.studyType;
+    if (studyType && (REVIEW_STUDY_TYPES as readonly string[]).includes(studyType)) {
+      reviews.push(p);
+    } else {
+      studies.push(p);
+    }
+  }
+  return { reviews, studies };
+}
+
+/** Build subsumption relations from OpenAlex reference lists.
+ *
+ *  @param reviews — review papers from the result set
+ *  @param studies — individual study papers from the result set
+ *  @param refsMap — map of review openAlexId → list of referenced work IDs
+ *  @returns relations where a study appears in a review's reference list */
+export function buildRelationsFromRefs(
+  reviews: OverlapPaper[],
+  studies: OverlapPaper[],
+  refsMap: Map<string, string[]>,
+): SubsumptionRelation[] {
+  const relations: SubsumptionRelation[] = [];
+  const studyIdSet = new Set(studies.map((s) => s.openAlexId));
+
+  for (const review of reviews) {
+    const refs = refsMap.get(review.openAlexId);
+    if (!refs) continue;
+
+    // OpenAlex referenced_works are full URLs; study IDs may also be full URLs
+    const refsSet = new Set(refs);
+
+    for (const studyId of studyIdSet) {
+      if (refsSet.has(studyId)) {
+        relations.push({
+          reviewId: review.openAlexId,
+          studyId,
+          detectionMethod: "citation-graph",
+          confidence: 1.0,
+        });
+      }
+    }
+  }
+  return relations;
+}
+
+/** Identify study-review pairs not yet matched by citation graph,
+ *  where the study was published in the same year or before the review
+ *  and both have abstracts (so LLM can compare them). */
+export function findUnmatchedPairs(
+  reviews: OverlapPaper[],
+  studies: OverlapPaper[],
+  existingRelations: SubsumptionRelation[],
+): Array<{ review: OverlapPaper; study: OverlapPaper }> {
+  const matchedPairs = new Set(
+    existingRelations.map((r) => `${r.reviewId}::${r.studyId}`),
+  );
+
+  const pairs: Array<{ review: OverlapPaper; study: OverlapPaper }> = [];
+  for (const review of reviews) {
+    for (const study of studies) {
+      const pairKey = `${review.openAlexId}::${study.openAlexId}`;
+      if (matchedPairs.has(pairKey)) continue;
+
+      // Only consider LLM fallback if study predates or matches review year
+      if (study.year != null && review.year != null && study.year > review.year) {
+        continue;
+      }
+
+      // Both must have abstracts for LLM comparison
+      if (!study.abstract || !review.abstract) continue;
+
+      pairs.push({ review, study });
+    }
+  }
+  return pairs;
+}
+
+/** Derive per-paper overlap status from the full set of relations.
+ *
+ *  - Papers with review study types get "review"
+ *  - Studies that appear in any relation as the studyId get "subsumed"
+ *  - Remaining studies get "novel"
+ *  - If there are no reviews at all, every paper gets "no-reviews" */
+export function derivePaperStatus(
+  papers: OverlapPaper[],
+  relations: SubsumptionRelation[],
+): Record<string, PaperOverlapStatus> {
+  const { reviews } = partitionPapers(papers);
+
+  if (reviews.length === 0) {
+    const status: Record<string, PaperOverlapStatus> = {};
+    for (const p of papers) {
+      status[p.openAlexId] = "no-reviews";
+    }
+    return status;
+  }
+
+  const reviewIds = new Set(reviews.map((r) => r.openAlexId));
+  const subsumedIds = new Set(relations.map((r) => r.studyId));
+
+  const status: Record<string, PaperOverlapStatus> = {};
+  for (const p of papers) {
+    if (reviewIds.has(p.openAlexId)) {
+      status[p.openAlexId] = "review";
+    } else if (subsumedIds.has(p.openAlexId)) {
+      status[p.openAlexId] = "subsumed";
+    } else {
+      status[p.openAlexId] = "novel";
+    }
+  }
+  return status;
+}

--- a/app/api/evidence-overlap/route.ts
+++ b/app/api/evidence-overlap/route.ts
@@ -25,12 +25,16 @@ import {
   derivePaperStatus,
 } from "./overlapUtils";
 
-if (!process.env.OPENALEX_MAILTO) {
-  throw new Error(
-    "OPENALEX_MAILTO env var is required — OpenAlex's polite pool needs a real contact email.",
-  );
+function getOpenAlexMailto(): string {
+  const mailto = process.env.OPENALEX_MAILTO;
+  if (!mailto) {
+    throw new Error(
+      "OPENALEX_MAILTO env var is required — OpenAlex's polite pool needs a real contact email. " +
+      "See https://docs.openalex.org/how-to-use-the-api/rate-limits-and-authentication",
+    );
+  }
+  return mailto;
 }
-const OPENALEX_MAILTO: string = process.env.OPENALEX_MAILTO;
 const MAX_PAPERS = 20;
 
 // ---------------------------------------------------------------------------
@@ -140,7 +144,7 @@ export async function POST(request: NextRequest) {
 
     // Step 1: Fetch referenced_works for review papers from OpenAlex
     const reviewIds = [...reviewIdSet];
-    const refWorks = await fetchWorksByIds(reviewIds, OPENALEX_MAILTO);
+    const refWorks = await fetchWorksByIds(reviewIds, getOpenAlexMailto());
 
     // Build a map of review ID → referenced work IDs
     const refsMap = new Map<string, string[]>();

--- a/app/api/evidence-overlap/route.ts
+++ b/app/api/evidence-overlap/route.ts
@@ -1,0 +1,253 @@
+/**
+ * API route for overlap and subsumption detection between evidence papers.
+ *
+ * Given scored papers from an evidence slot, detects which individual studies
+ * are already covered by review papers (meta-analyses, systematic reviews)
+ * in the same result set. Uses OpenAlex's reference lists as primary signal
+ * and LLM abstract comparison as fallback for unmatched pairs.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { callLlm, OpenRouterError } from "@/app/lib/llm/callLlm";
+import { CLAUDE_SONNET } from "@/app/lib/llm/models";
+import { stripCodeFences } from "@/app/lib/utils/stripCodeFences";
+import { fetchWorksByIds } from "@/app/api/evidence-search/openAlexUtils";
+import {
+  type EvidenceOverlapRequest,
+  type EvidenceOverlapResponse,
+  type PaperOverlapStatus,
+  type SubsumptionRelation,
+} from "@/app/lib/types/evidence";
+import {
+  partitionPapers,
+  buildRelationsFromRefs,
+  findUnmatchedPairs,
+  derivePaperStatus,
+} from "./overlapUtils";
+
+if (!process.env.OPENALEX_MAILTO) {
+  throw new Error(
+    "OPENALEX_MAILTO env var is required — OpenAlex's polite pool needs a real contact email.",
+  );
+}
+const OPENALEX_MAILTO: string = process.env.OPENALEX_MAILTO;
+const MAX_PAPERS = 20;
+
+// ---------------------------------------------------------------------------
+// LLM fallback prompt for unmatched pairs
+// ---------------------------------------------------------------------------
+
+const OVERLAP_SYSTEM_PROMPT = `You determine whether a review paper (meta-analysis or systematic review) likely includes a specific individual study in its analysis.
+
+For each pair, assess based on the abstracts whether the review would have covered the study. Consider:
+- Do they address the same specific topic and population?
+- Is the study's methodology type one that the review explicitly includes?
+- Are the outcome measures compatible?
+
+Return a JSON object:
+{
+  "results": [
+    {
+      "reviewId": "...",
+      "studyId": "...",
+      "included": true,
+      "confidence": 0.8
+    }
+  ]
+}
+
+- "included": true if the review likely includes/covers this study, false otherwise
+- "confidence": 0.0-1.0, how confident you are in this assessment
+- Only mark as included with confidence >= 0.6 if the topical and methodological overlap is clear`;
+
+const OVERLAP_SCHEMA = {
+  type: "json_schema" as const,
+  json_schema: {
+    name: "overlap_results",
+    strict: true,
+    schema: {
+      type: "object",
+      required: ["results"],
+      additionalProperties: false,
+      properties: {
+        results: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["reviewId", "studyId", "included", "confidence"],
+            additionalProperties: false,
+            properties: {
+              reviewId: { type: "string" },
+              studyId: { type: "string" },
+              included: { type: "boolean" },
+              confidence: { type: "number" },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as Partial<EvidenceOverlapRequest>;
+
+    // Validate request
+    if (!Array.isArray(body.papers) || body.papers.length === 0) {
+      return NextResponse.json(
+        { error: "papers array is required and must not be empty" },
+        { status: 400 },
+      );
+    }
+    if (body.papers.length > MAX_PAPERS) {
+      return NextResponse.json(
+        { error: `Too many papers (max ${MAX_PAPERS})` },
+        { status: 400 },
+      );
+    }
+
+    // Validate that papers have reliability scores
+    for (let i = 0; i < body.papers.length; i++) {
+      const p = body.papers[i];
+      if (!p || typeof p.openAlexId !== "string") {
+        return NextResponse.json(
+          { error: `Paper at index ${i} is missing openAlexId` },
+          { status: 400 },
+        );
+      }
+    }
+
+    const papers = body.papers;
+    const { reviews, studies } = partitionPapers(papers);
+
+    // If no reviews, every paper is "no-reviews" — skip OpenAlex and LLM calls
+    if (reviews.length === 0) {
+      const paperStatus: Record<string, PaperOverlapStatus> = {};
+      for (const p of papers) {
+        paperStatus[p.openAlexId] = "no-reviews";
+      }
+      const response: EvidenceOverlapResponse = {
+        analysis: {
+          relations: [],
+          paperStatus,
+          analyzedAt: new Date().toISOString(),
+        },
+      };
+      return NextResponse.json(response);
+    }
+
+    // Step 1: Fetch referenced_works for review papers from OpenAlex
+    const reviewIds = reviews.map((r) => r.openAlexId);
+    const refWorks = await fetchWorksByIds(reviewIds, OPENALEX_MAILTO);
+
+    // Build a map of review ID → referenced work IDs
+    const refsMap = new Map<string, string[]>();
+    for (const work of refWorks) {
+      if (work.id && work.referenced_works) {
+        refsMap.set(work.id, work.referenced_works);
+      }
+    }
+
+    // Step 2: Build citation-graph relations
+    const citationRelations = buildRelationsFromRefs(reviews, studies, refsMap);
+
+    // Step 3: LLM fallback for unmatched pairs
+    const unmatchedPairs = findUnmatchedPairs(reviews, studies, citationRelations);
+    let llmRelations: SubsumptionRelation[] = [];
+
+    if (unmatchedPairs.length > 0) {
+      llmRelations = await classifyOverlapWithLlm(unmatchedPairs);
+    }
+
+    // Step 4: Combine relations and derive status
+    const allRelations = [...citationRelations, ...llmRelations];
+    const paperStatus = derivePaperStatus(papers, allRelations);
+
+    const response: EvidenceOverlapResponse = {
+      analysis: {
+        relations: allRelations,
+        paperStatus,
+        analyzedAt: new Date().toISOString(),
+      },
+    };
+    return NextResponse.json(response);
+  } catch (err) {
+    if (err instanceof OpenRouterError) {
+      return NextResponse.json(
+        { error: err.message, details: err.details },
+        { status: 502 },
+      );
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("[evidence-overlap] Error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// LLM fallback classification
+// ---------------------------------------------------------------------------
+
+type PaperPair = { review: EvidenceOverlapRequest["papers"][number]; study: EvidenceOverlapRequest["papers"][number] };
+
+async function classifyOverlapWithLlm(
+  pairs: PaperPair[],
+): Promise<SubsumptionRelation[]> {
+  const pairDescriptions = pairs.map((pair, i) => {
+    const reviewAbstract = pair.review.abstract?.slice(0, 300) ?? "(no abstract)";
+    const studyAbstract = pair.study.abstract?.slice(0, 300) ?? "(no abstract)";
+    return `Pair ${i + 1}:
+  Review (ID: ${pair.review.openAlexId}): "${pair.review.title}" (${pair.review.year ?? "year unknown"})
+  Abstract: ${reviewAbstract}
+  Study (ID: ${pair.study.openAlexId}): "${pair.study.title}" (${pair.study.year ?? "year unknown"})
+  Abstract: ${studyAbstract}`;
+  });
+
+  const userMessage = `Assess whether each review paper likely includes the paired individual study:
+
+${pairDescriptions.join("\n\n")}`;
+
+  try {
+    const { text } = await callLlm({
+      endpoint: "evidence-overlap/classify",
+      systemPrompt: OVERLAP_SYSTEM_PROMPT,
+      userContent: userMessage,
+      maxTokens: 2048,
+      openRouterModel: CLAUDE_SONNET,
+      responseFormat: OVERLAP_SCHEMA,
+    });
+
+    if (!text) return [];
+
+    const parsed = JSON.parse(stripCodeFences(text));
+    if (!Array.isArray(parsed.results)) return [];
+
+    const relations: SubsumptionRelation[] = [];
+    for (const result of parsed.results) {
+      if (
+        result.included === true &&
+        typeof result.confidence === "number" &&
+        result.confidence >= 0.6 &&
+        typeof result.reviewId === "string" &&
+        typeof result.studyId === "string"
+      ) {
+        relations.push({
+          reviewId: result.reviewId,
+          studyId: result.studyId,
+          detectionMethod: "llm-fallback",
+          confidence: Math.min(Math.max(result.confidence, 0), 1),
+        });
+      }
+    }
+    return relations;
+  } catch (err) {
+    // LLM fallback is best-effort — log and continue with citation-graph results only
+    console.error("[evidence-overlap] LLM fallback error:", err);
+    return [];
+  }
+}

--- a/app/api/evidence-overlap/route.ts
+++ b/app/api/evidence-overlap/route.ts
@@ -15,10 +15,10 @@ import { fetchWorksByIds } from "@/app/api/evidence-search/openAlexUtils";
 import {
   type EvidenceOverlapRequest,
   type EvidenceOverlapResponse,
-  type PaperOverlapStatus,
   type SubsumptionRelation,
 } from "@/app/lib/types/evidence";
 import {
+  type OverlapPaper,
   partitionPapers,
   buildRelationsFromRefs,
   findUnmatchedPairs,
@@ -124,17 +124,14 @@ export async function POST(request: NextRequest) {
 
     const papers = body.papers;
     const { reviews, studies } = partitionPapers(papers);
+    const reviewIdSet = new Set(reviews.map((r) => r.openAlexId));
 
     // If no reviews, every paper is "no-reviews" — skip OpenAlex and LLM calls
     if (reviews.length === 0) {
-      const paperStatus: Record<string, PaperOverlapStatus> = {};
-      for (const p of papers) {
-        paperStatus[p.openAlexId] = "no-reviews";
-      }
       const response: EvidenceOverlapResponse = {
         analysis: {
           relations: [],
-          paperStatus,
+          paperStatus: derivePaperStatus(papers, [], reviewIdSet),
           analyzedAt: new Date().toISOString(),
         },
       };
@@ -142,7 +139,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Step 1: Fetch referenced_works for review papers from OpenAlex
-    const reviewIds = reviews.map((r) => r.openAlexId);
+    const reviewIds = [...reviewIdSet];
     const refWorks = await fetchWorksByIds(reviewIds, OPENALEX_MAILTO);
 
     // Build a map of review ID → referenced work IDs
@@ -166,7 +163,7 @@ export async function POST(request: NextRequest) {
 
     // Step 4: Combine relations and derive status
     const allRelations = [...citationRelations, ...llmRelations];
-    const paperStatus = derivePaperStatus(papers, allRelations);
+    const paperStatus = derivePaperStatus(papers, allRelations, reviewIdSet);
 
     const response: EvidenceOverlapResponse = {
       analysis: {
@@ -193,7 +190,7 @@ export async function POST(request: NextRequest) {
 // LLM fallback classification
 // ---------------------------------------------------------------------------
 
-type PaperPair = { review: EvidenceOverlapRequest["papers"][number]; study: EvidenceOverlapRequest["papers"][number] };
+type PaperPair = { review: OverlapPaper; study: OverlapPaper };
 
 async function classifyOverlapWithLlm(
   pairs: PaperPair[],

--- a/app/api/evidence-search/openAlexUtils.test.ts
+++ b/app/api/evidence-search/openAlexUtils.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   reconstructAbstract,
   mapOpenAlexWork,
   deduplicatePapers,
+  fetchWorksByIds,
   type OpenAlexWork,
 } from "./openAlexUtils";
 import type { EvidencePaper } from "@/app/lib/types/evidence";
@@ -151,5 +152,87 @@ describe("deduplicatePapers", () => {
 
   it("returns empty array for empty input", () => {
     expect(deduplicatePapers([])).toEqual([]);
+  });
+});
+
+describe("fetchWorksByIds", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty array for empty input", async () => {
+    const result = await fetchWorksByIds([], "test@example.com");
+    expect(result).toEqual([]);
+  });
+
+  it("fetches works by ID with correct URL params", async () => {
+    const mockResponse = {
+      results: [
+        {
+          id: "https://openalex.org/W123",
+          referenced_works: ["https://openalex.org/W456", "https://openalex.org/W789"],
+        },
+      ],
+    };
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    } as Response);
+
+    const result = await fetchWorksByIds(
+      ["https://openalex.org/W123"],
+      "test@example.com",
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].referenced_works).toEqual([
+      "https://openalex.org/W456",
+      "https://openalex.org/W789",
+    ]);
+
+    // Verify URL construction
+    const calledUrl = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(calledUrl.searchParams.get("filter")).toBe("openalex:W123");
+    expect(calledUrl.searchParams.get("select")).toBe("id,referenced_works");
+    expect(calledUrl.searchParams.get("mailto")).toBe("test@example.com");
+  });
+
+  it("strips full URL prefix from IDs", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ results: [] }),
+    } as Response);
+
+    await fetchWorksByIds(
+      ["https://openalex.org/W111", "https://openalex.org/W222"],
+      "test@example.com",
+    );
+
+    const calledUrl = new URL(fetchSpy.mock.calls[0][0] as string);
+    expect(calledUrl.searchParams.get("filter")).toBe("openalex:W111|W222");
+  });
+
+  it("returns empty array on HTTP error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+    } as Response);
+
+    const result = await fetchWorksByIds(
+      ["https://openalex.org/W123"],
+      "test@example.com",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array on network error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network failure"));
+
+    const result = await fetchWorksByIds(
+      ["https://openalex.org/W123"],
+      "test@example.com",
+    );
+    expect(result).toEqual([]);
   });
 });

--- a/app/api/evidence-search/openAlexUtils.ts
+++ b/app/api/evidence-search/openAlexUtils.ts
@@ -88,7 +88,7 @@ export function mapOpenAlexWork(work: OpenAlexWork): EvidencePaper {
 // Batch fetch by ID (for overlap detection — retrieves referenced_works)
 // ---------------------------------------------------------------------------
 
-const OPENALEX_API_URL = "https://api.openalex.org/works";
+export const OPENALEX_API_URL = "https://api.openalex.org/works";
 const FETCH_BY_ID_TIMEOUT_MS = 10_000;
 
 /** Batch-fetch OpenAlex works by ID, returning only `id` and `referenced_works`.

--- a/app/api/evidence-search/openAlexUtils.ts
+++ b/app/api/evidence-search/openAlexUtils.ts
@@ -59,6 +59,8 @@ export type OpenAlexWork = {
   open_access?: OpenAlexOpenAccess | null;
   doi?: string | null;
   relevance_score?: number | null;
+  /** List of OpenAlex Work IDs this paper cites (full URLs like "https://openalex.org/W123") */
+  referenced_works?: string[];
 };
 
 /** Map a raw OpenAlex work object to our EvidencePaper type. */
@@ -80,6 +82,58 @@ export function mapOpenAlexWork(work: OpenAlexWork): EvidencePaper {
     reliability: null,
     relatedness: null,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Batch fetch by ID (for overlap detection — retrieves referenced_works)
+// ---------------------------------------------------------------------------
+
+const OPENALEX_API_URL = "https://api.openalex.org/works";
+const FETCH_BY_ID_TIMEOUT_MS = 10_000;
+
+/** Batch-fetch OpenAlex works by ID, returning only `id` and `referenced_works`.
+ *  Uses the pipe-separated filter syntax: `filter=openalex:W123|W456`.
+ *  OpenAlex supports up to 50 IDs per request. */
+export async function fetchWorksByIds(
+  ids: string[],
+  mailto: string,
+): Promise<OpenAlexWork[]> {
+  if (ids.length === 0) return [];
+
+  // Strip full URL prefix if present — OpenAlex filter wants bare IDs like "W123"
+  const shortIds = ids.map((id) =>
+    id.replace("https://openalex.org/", ""),
+  );
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_BY_ID_TIMEOUT_MS);
+
+  try {
+    const url = new URL(OPENALEX_API_URL);
+    url.searchParams.set("filter", `openalex:${shortIds.join("|")}`);
+    url.searchParams.set("select", "id,referenced_works");
+    url.searchParams.set("per_page", String(ids.length));
+    url.searchParams.set("mailto", mailto);
+
+    const res = await fetch(url.toString(), { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (!res.ok) {
+      console.error(`[openAlexUtils] fetchWorksByIds returned ${res.status}`);
+      return [];
+    }
+
+    const data = await res.json();
+    return (data.results ?? []) as OpenAlexWork[];
+  } catch (err) {
+    clearTimeout(timeout);
+    if (err instanceof Error && err.name === "AbortError") {
+      console.error("[openAlexUtils] fetchWorksByIds timeout");
+    } else {
+      console.error("[openAlexUtils] fetchWorksByIds error:", err);
+    }
+    return [];
+  }
 }
 
 /** Deduplicate papers by openAlexId, keeping the first occurrence. */

--- a/app/api/evidence-search/route.ts
+++ b/app/api/evidence-search/route.ts
@@ -2,10 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { callLlm, OpenRouterError } from "@/app/lib/llm/callLlm";
 import { CLAUDE_SONNET } from "@/app/lib/llm/models";
 import { stripCodeFences } from "@/app/lib/utils/stripCodeFences";
-import { mapOpenAlexWork, deduplicatePapers, type OpenAlexWork } from "./openAlexUtils";
+import { OPENALEX_API_URL, mapOpenAlexWork, deduplicatePapers, type OpenAlexWork } from "./openAlexUtils";
 import { EVIDENCE_ARTIFACT_TYPES, type EvidenceSearchRequest, type EvidenceSearchResponse } from "@/app/lib/types/evidence";
-
-const OPENALEX_API_URL = "https://api.openalex.org/works";
 const OPENALEX_TIMEOUT_MS = 10_000;
 function getOpenAlexMailto(): string {
   const mailto = process.env.OPENALEX_MAILTO;

--- a/app/components/features/evidence-search/EvidencePaperCard.tsx
+++ b/app/components/features/evidence-search/EvidencePaperCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import type { EvidencePaper } from "@/app/lib/types/evidence";
+import type { EvidencePaper, PaperOverlapStatus } from "@/app/lib/types/evidence";
 import { STUDY_TYPE_LABELS } from "@/app/lib/types/evidence";
 import EvidenceScoreBadge from "./EvidenceScoreBadge";
 
@@ -19,7 +19,21 @@ function paperUrl(paper: EvidencePaper): string | null {
   return null;
 }
 
-export default function EvidencePaperCard({ paper }: { paper: EvidencePaper }) {
+const OVERLAP_BADGE_STYLES: Record<Exclude<PaperOverlapStatus, "no-reviews">, { label: string; className: string }> = {
+  review: { label: "Review paper", className: "text-blue-700 bg-blue-50 border-blue-200" },
+  subsumed: { label: "Included in review", className: "text-amber-700 bg-amber-50 border-amber-200" },
+  novel: { label: "Novel", className: "text-green-700 bg-green-50 border-green-200" },
+};
+
+export default function EvidencePaperCard({
+  paper,
+  overlapStatus,
+  subsumingReviewTitle,
+}: {
+  paper: EvidencePaper;
+  overlapStatus?: PaperOverlapStatus;
+  subsumingReviewTitle?: string;
+}) {
   const [expanded, setExpanded] = useState(false);
   const url = paperUrl(paper);
   const needsTruncation = paper.abstract && paper.abstract.length > ABSTRACT_TRUNCATE;
@@ -38,25 +52,39 @@ export default function EvidencePaperCard({ paper }: { paper: EvidencePaper }) {
           )}
         </div>
 
-        {/* Score badges */}
-        {hasScores && (
-          <div className="flex items-center gap-1 shrink-0">
-            {paper.reliability && (
-              <EvidenceScoreBadge
-                label="Rel"
-                score={paper.reliability.score}
-                tooltip={`Reliability: ${paper.reliability.rationale}`}
-              />
-            )}
-            {paper.relatedness && (
-              <EvidenceScoreBadge
-                label="Fit"
-                score={paper.relatedness.score}
-                tooltip={`Relatedness: ${paper.relatedness.rationale}`}
-              />
-            )}
-          </div>
-        )}
+        {/* Score and overlap badges */}
+        <div className="flex items-center gap-1 shrink-0">
+          {hasScores && (
+            <>
+              {paper.reliability && (
+                <EvidenceScoreBadge
+                  label="Rel"
+                  score={paper.reliability.score}
+                  tooltip={`Reliability: ${paper.reliability.rationale}`}
+                />
+              )}
+              {paper.relatedness && (
+                <EvidenceScoreBadge
+                  label="Fit"
+                  score={paper.relatedness.score}
+                  tooltip={`Relatedness: ${paper.relatedness.rationale}`}
+                />
+              )}
+            </>
+          )}
+          {overlapStatus && overlapStatus !== "no-reviews" && (
+            <span
+              className={`inline-flex items-center rounded border px-1 py-0.5 text-[10px] font-mono cursor-default ${OVERLAP_BADGE_STYLES[overlapStatus].className}`}
+              title={
+                overlapStatus === "subsumed" && subsumingReviewTitle
+                  ? `Included in: ${subsumingReviewTitle}`
+                  : undefined
+              }
+            >
+              {OVERLAP_BADGE_STYLES[overlapStatus].label}
+            </span>
+          )}
+        </div>
       </div>
 
       <div className="flex flex-wrap items-center gap-x-2 text-xs text-[#6B6560]">
@@ -75,6 +103,13 @@ export default function EvidencePaperCard({ paper }: { paper: EvidencePaper }) {
           </span>
         )}
       </div>
+
+      {/* Subsuming review detail */}
+      {overlapStatus === "subsumed" && subsumingReviewTitle && (
+        <div className="text-[10px] text-[#9A9590] mt-0.5">
+          Covered by: {subsumingReviewTitle}
+        </div>
+      )}
 
       {/* Red flags */}
       {paper.reliability && paper.reliability.redFlags.length > 0 && (

--- a/app/components/features/evidence-search/EvidencePaperCard.tsx
+++ b/app/components/features/evidence-search/EvidencePaperCard.tsx
@@ -37,7 +37,6 @@ export default function EvidencePaperCard({
   const [expanded, setExpanded] = useState(false);
   const url = paperUrl(paper);
   const needsTruncation = paper.abstract && paper.abstract.length > ABSTRACT_TRUNCATE;
-  const hasScores = paper.reliability !== null || paper.relatedness !== null;
 
   return (
     <div className="rounded border border-[#DDD9D5] bg-white px-3 py-2 space-y-1">
@@ -52,25 +51,20 @@ export default function EvidencePaperCard({
           )}
         </div>
 
-        {/* Score and overlap badges */}
         <div className="flex items-center gap-1 shrink-0">
-          {hasScores && (
-            <>
-              {paper.reliability && (
-                <EvidenceScoreBadge
-                  label="Rel"
-                  score={paper.reliability.score}
-                  tooltip={`Reliability: ${paper.reliability.rationale}`}
-                />
-              )}
-              {paper.relatedness && (
-                <EvidenceScoreBadge
-                  label="Fit"
-                  score={paper.relatedness.score}
-                  tooltip={`Relatedness: ${paper.relatedness.rationale}`}
-                />
-              )}
-            </>
+          {paper.reliability && (
+            <EvidenceScoreBadge
+              label="Rel"
+              score={paper.reliability.score}
+              tooltip={`Reliability: ${paper.reliability.rationale}`}
+            />
+          )}
+          {paper.relatedness && (
+            <EvidenceScoreBadge
+              label="Fit"
+              score={paper.relatedness.score}
+              tooltip={`Relatedness: ${paper.relatedness.rationale}`}
+            />
           )}
           {overlapStatus && overlapStatus !== "no-reviews" && (
             <span
@@ -96,7 +90,6 @@ export default function EvidencePaperCard({
             {paper.citedByCount} cited
           </span>
         )}
-        {/* Study type badge when scored */}
         {paper.reliability && (
           <span className="rounded bg-[#E8E4E0] px-1.5 py-0.5 text-[10px] font-mono text-[#6B6560]">
             {STUDY_TYPE_LABELS[paper.reliability.studyType]}

--- a/app/components/features/evidence-search/EvidenceResultsSection.tsx
+++ b/app/components/features/evidence-search/EvidenceResultsSection.tsx
@@ -43,11 +43,24 @@ export default function EvidenceResultsSection({
   const [open, setOpen] = useState(true);
   const count = slot.papers.length;
 
-  // Sort papers by score when scores are available
   const displayPapers = useMemo(() => {
     if (slot.scored) return sortByScore(slot.papers);
     return slot.papers;
   }, [slot.papers, slot.scored]);
+
+  // Pre-build a lookup from studyId → subsuming review title (avoids O(R*P) per render)
+  const subsumingReviewTitles = useMemo(() => {
+    if (!overlap) return new Map<string, string>();
+    const titleById = new Map(slot.papers.map((p) => [p.openAlexId, p.title]));
+    const result = new Map<string, string>();
+    for (const rel of overlap.relations) {
+      if (!result.has(rel.studyId)) {
+        const title = titleById.get(rel.reviewId);
+        if (title) result.set(rel.studyId, title);
+      }
+    }
+    return result;
+  }, [overlap, slot.papers]);
 
   return (
     <div className="mt-2 border-t border-[#DDD9D5] pt-2">
@@ -69,7 +82,6 @@ export default function EvidenceResultsSection({
         </button>
 
         <div className="flex items-center gap-1">
-          {/* Score button — only show when there are papers and scoring is available */}
           {onScore && count > 0 && (
             <button
               type="button"
@@ -85,7 +97,6 @@ export default function EvidenceResultsSection({
             </button>
           )}
 
-          {/* Overlap button — only show when scored and has review papers */}
           {onAnalyzeOverlap && slot.scored && hasReviews && (
             <button
               type="button"
@@ -113,33 +124,15 @@ export default function EvidenceResultsSection({
 
           {overlap && <OverlapSummary analysis={overlap} />}
 
-          {displayPapers.map((paper) => {
-            const status = overlap?.paperStatus[paper.openAlexId];
-            // Find the first review that subsumes this paper (for display)
-            const subsumingReviewTitle =
-              status === "subsumed"
-                ? (() => {
-                    const rel = overlap?.relations.find(
-                      (r) => r.studyId === paper.openAlexId,
-                    );
-                    if (!rel) return undefined;
-                    return slot.papers.find(
-                      (p) => p.openAlexId === rel.reviewId,
-                    )?.title;
-                  })()
-                : undefined;
+          {displayPapers.map((paper) => (
+            <EvidencePaperCard
+              key={paper.openAlexId}
+              paper={paper}
+              overlapStatus={overlap?.paperStatus[paper.openAlexId]}
+              subsumingReviewTitle={subsumingReviewTitles.get(paper.openAlexId)}
+            />
+          ))}
 
-            return (
-              <EvidencePaperCard
-                key={paper.openAlexId}
-                paper={paper}
-                overlapStatus={status}
-                subsumingReviewTitle={subsumingReviewTitle}
-              />
-            );
-          })}
-
-          {/* Search queries used (muted) */}
           {slot.searchQueries.length > 0 && (
             <div className="text-[10px] text-[#9A9590] mt-1">
               Searched: {slot.searchQueries.join(" | ")}

--- a/app/components/features/evidence-search/EvidenceResultsSection.tsx
+++ b/app/components/features/evidence-search/EvidenceResultsSection.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { EvidencePaper, EvidenceSlot } from "@/app/lib/types/evidence";
+import type { EvidencePaper, EvidenceSlot, OverlapAnalysis } from "@/app/lib/types/evidence";
 import EvidencePaperCard from "./EvidencePaperCard";
+import OverlapSummary from "./OverlapSummary";
 
 /** Sort papers by combined score (reliability + relatedness) descending.
  *  Unscored papers sort to the end. */
@@ -20,12 +21,24 @@ type EvidenceResultsSectionProps = {
   onScore?: () => void;
   /** Whether scoring is currently in progress */
   isScoring?: boolean;
+  /** Callback to trigger overlap analysis — rendered as button if provided */
+  onAnalyzeOverlap?: () => void;
+  /** Whether overlap analysis is currently in progress */
+  isAnalyzing?: boolean;
+  /** Overlap analysis results (null if not yet analyzed) */
+  overlap?: OverlapAnalysis | null;
+  /** Whether the slot has review-type papers (controls button visibility) */
+  hasReviews?: boolean;
 };
 
 export default function EvidenceResultsSection({
   slot,
   onScore,
   isScoring,
+  onAnalyzeOverlap,
+  isAnalyzing,
+  overlap,
+  hasReviews,
 }: EvidenceResultsSectionProps) {
   const [open, setOpen] = useState(true);
   const count = slot.papers.length;
@@ -55,21 +68,39 @@ export default function EvidenceResultsSection({
           )}
         </button>
 
-        {/* Score button — only show when there are papers and scoring is available */}
-        {onScore && count > 0 && (
-          <button
-            type="button"
-            disabled={isScoring}
-            onClick={onScore}
-            className="text-[10px] text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded px-1.5 py-0.5 hover:bg-[#F5F1ED] disabled:opacity-50 disabled:cursor-wait"
-          >
-            {isScoring
-              ? "Scoring..."
-              : slot.scored
-                ? "Re-score"
-                : "Score papers"}
-          </button>
-        )}
+        <div className="flex items-center gap-1">
+          {/* Score button — only show when there are papers and scoring is available */}
+          {onScore && count > 0 && (
+            <button
+              type="button"
+              disabled={isScoring}
+              onClick={onScore}
+              className="text-[10px] text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded px-1.5 py-0.5 hover:bg-[#F5F1ED] disabled:opacity-50 disabled:cursor-wait"
+            >
+              {isScoring
+                ? "Scoring..."
+                : slot.scored
+                  ? "Re-score"
+                  : "Score papers"}
+            </button>
+          )}
+
+          {/* Overlap button — only show when scored and has review papers */}
+          {onAnalyzeOverlap && slot.scored && hasReviews && (
+            <button
+              type="button"
+              disabled={isAnalyzing}
+              onClick={onAnalyzeOverlap}
+              className="text-[10px] text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded px-1.5 py-0.5 hover:bg-[#F5F1ED] disabled:opacity-50 disabled:cursor-wait"
+            >
+              {isAnalyzing
+                ? "Analyzing..."
+                : overlap
+                  ? "Re-analyze overlap"
+                  : "Check overlap"}
+            </button>
+          )}
+        </div>
       </div>
 
       {open && (
@@ -80,9 +111,33 @@ export default function EvidenceResultsSection({
             </p>
           )}
 
-          {displayPapers.map((paper) => (
-            <EvidencePaperCard key={paper.openAlexId} paper={paper} />
-          ))}
+          {overlap && <OverlapSummary analysis={overlap} />}
+
+          {displayPapers.map((paper) => {
+            const status = overlap?.paperStatus[paper.openAlexId];
+            // Find the first review that subsumes this paper (for display)
+            const subsumingReviewTitle =
+              status === "subsumed"
+                ? (() => {
+                    const rel = overlap?.relations.find(
+                      (r) => r.studyId === paper.openAlexId,
+                    );
+                    if (!rel) return undefined;
+                    return slot.papers.find(
+                      (p) => p.openAlexId === rel.reviewId,
+                    )?.title;
+                  })()
+                : undefined;
+
+            return (
+              <EvidencePaperCard
+                key={paper.openAlexId}
+                paper={paper}
+                overlapStatus={status}
+                subsumingReviewTitle={subsumingReviewTitle}
+              />
+            );
+          })}
 
           {/* Search queries used (muted) */}
           {slot.searchQueries.length > 0 && (

--- a/app/components/features/evidence-search/EvidenceResultsSection.tsx
+++ b/app/components/features/evidence-search/EvidenceResultsSection.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { EvidencePaper, EvidenceSlot } from "@/app/lib/types/evidence";
+import type { EvidencePaper, EvidenceSlot, OverlapAnalysis } from "@/app/lib/types/evidence";
 import EvidencePaperCard from "./EvidencePaperCard";
+import OverlapSummary from "./OverlapSummary";
 
 /** Sort papers by combined score (reliability + relatedness) descending.
  *  Unscored papers sort to the end. */
@@ -20,12 +21,24 @@ type EvidenceResultsSectionProps = {
   onScore?: () => void;
   /** Whether scoring is currently in progress */
   isScoring?: boolean;
+  /** Callback to trigger overlap analysis — rendered as button if provided */
+  onAnalyzeOverlap?: () => void;
+  /** Whether overlap analysis is currently in progress */
+  isAnalyzing?: boolean;
+  /** Overlap analysis results (null if not yet analyzed) */
+  overlap?: OverlapAnalysis | null;
+  /** Whether the slot has review-type papers (controls button visibility) */
+  hasReviews?: boolean;
 };
 
 export default function EvidenceResultsSection({
   slot,
   onScore,
   isScoring,
+  onAnalyzeOverlap,
+  isAnalyzing,
+  overlap,
+  hasReviews,
 }: EvidenceResultsSectionProps) {
   const [open, setOpen] = useState(true);
   const count = slot.papers.length;
@@ -55,21 +68,39 @@ export default function EvidenceResultsSection({
           )}
         </button>
 
-        {/* Score button — only show when there are papers and scoring is available */}
-        {onScore && count > 0 && (
-          <button
-            type="button"
-            disabled={isScoring}
-            onClick={onScore}
-            className="text-[10px] text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded px-1.5 py-0.5 hover:bg-[#F5F1ED] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ink-black)]/30 active:bg-[#ECE7E2] disabled:opacity-50 disabled:cursor-wait"
-          >
-            {isScoring
-              ? "Scoring..."
-              : slot.scored
-                ? "Re-score"
-                : "Score papers"}
-          </button>
-        )}
+        <div className="flex items-center gap-1">
+          {/* Score button — only show when there are papers and scoring is available */}
+          {onScore && count > 0 && (
+            <button
+              type="button"
+              disabled={isScoring}
+              onClick={onScore}
+              className="text-[10px] text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded px-1.5 py-0.5 hover:bg-[#F5F1ED] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ink-black)]/30 active:bg-[#ECE7E2] disabled:opacity-50 disabled:cursor-wait"
+            >
+              {isScoring
+                ? "Scoring..."
+                : slot.scored
+                  ? "Re-score"
+                  : "Score papers"}
+            </button>
+          )}
+
+          {/* Overlap button — only show when scored and has review papers */}
+          {onAnalyzeOverlap && slot.scored && hasReviews && (
+            <button
+              type="button"
+              disabled={isAnalyzing}
+              onClick={onAnalyzeOverlap}
+              className="text-[10px] text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded px-1.5 py-0.5 hover:bg-[#F5F1ED] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ink-black)]/30 active:bg-[#ECE7E2] disabled:opacity-50 disabled:cursor-wait"
+            >
+              {isAnalyzing
+                ? "Analyzing..."
+                : overlap
+                  ? "Re-analyze overlap"
+                  : "Check overlap"}
+            </button>
+          )}
+        </div>
       </div>
 
       {open && (
@@ -80,9 +111,33 @@ export default function EvidenceResultsSection({
             </p>
           )}
 
-          {displayPapers.map((paper) => (
-            <EvidencePaperCard key={paper.openAlexId} paper={paper} />
-          ))}
+          {overlap && <OverlapSummary analysis={overlap} />}
+
+          {displayPapers.map((paper) => {
+            const status = overlap?.paperStatus[paper.openAlexId];
+            // Find the first review that subsumes this paper (for display)
+            const subsumingReviewTitle =
+              status === "subsumed"
+                ? (() => {
+                    const rel = overlap?.relations.find(
+                      (r) => r.studyId === paper.openAlexId,
+                    );
+                    if (!rel) return undefined;
+                    return slot.papers.find(
+                      (p) => p.openAlexId === rel.reviewId,
+                    )?.title;
+                  })()
+                : undefined;
+
+            return (
+              <EvidencePaperCard
+                key={paper.openAlexId}
+                paper={paper}
+                overlapStatus={status}
+                subsumingReviewTitle={subsumingReviewTitle}
+              />
+            );
+          })}
 
           {/* Search queries used (muted) */}
           {slot.searchQueries.length > 0 && (

--- a/app/components/features/evidence-search/FindEvidenceButton.tsx
+++ b/app/components/features/evidence-search/FindEvidenceButton.tsx
@@ -2,6 +2,7 @@
 
 import { useEvidenceSearch } from "@/app/hooks/useEvidenceSearch";
 import { useEvidenceScoring } from "@/app/hooks/useEvidenceScoring";
+import { useEvidenceOverlap } from "@/app/hooks/useEvidenceOverlap";
 import EvidenceResultsSection from "./EvidenceResultsSection";
 import type { EvidenceArtifactType } from "@/app/lib/types/evidence";
 
@@ -20,6 +21,7 @@ export default function FindEvidenceButton({
 }: FindEvidenceButtonProps) {
   const { slot, isLoading, error, search } = useEvidenceSearch(artifactType, elementId);
   const { isScoring, score } = useEvidenceScoring(artifactType, elementId);
+  const { overlap, isAnalyzing, analyze, hasReviews } = useEvidenceOverlap(artifactType, elementId);
 
   return (
     <div className="mt-1.5">
@@ -45,6 +47,10 @@ export default function FindEvidenceButton({
           slot={slot}
           onScore={() => score(elementContent)}
           isScoring={isScoring}
+          onAnalyzeOverlap={analyze}
+          isAnalyzing={isAnalyzing}
+          overlap={overlap}
+          hasReviews={hasReviews}
         />
       )}
     </div>

--- a/app/components/features/evidence-search/OverlapSummary.tsx
+++ b/app/components/features/evidence-search/OverlapSummary.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { OverlapAnalysis } from "@/app/lib/types/evidence";
+
+/**
+ * Compact summary bar showing overlap analysis counts.
+ * Displayed above the paper list when overlap analysis exists.
+ */
+export default function OverlapSummary({ analysis }: { analysis: OverlapAnalysis }) {
+  const statusValues = Object.values(analysis.paperStatus);
+  const reviewCount = statusValues.filter((s) => s === "review").length;
+  const subsumedCount = statusValues.filter((s) => s === "subsumed").length;
+  const novelCount = statusValues.filter((s) => s === "novel").length;
+
+  if (reviewCount === 0) return null;
+
+  const parts: string[] = [];
+  if (subsumedCount > 0) {
+    parts.push(
+      `${subsumedCount} ${subsumedCount === 1 ? "study" : "studies"} subsumed by ${reviewCount} ${reviewCount === 1 ? "review" : "reviews"}`,
+    );
+  }
+  if (novelCount > 0) {
+    parts.push(
+      `${novelCount} novel ${novelCount === 1 ? "study" : "studies"}`,
+    );
+  }
+  if (parts.length === 0) {
+    parts.push(`${reviewCount} ${reviewCount === 1 ? "review" : "reviews"}, no individual studies`);
+  }
+
+  return (
+    <div className="text-[10px] text-[#6B6560] bg-[#F5F1ED] border border-[#DDD9D5] rounded px-2 py-1 mb-2">
+      {parts.join(", ")}
+    </div>
+  );
+}

--- a/app/hooks/useEvidenceOverlap.ts
+++ b/app/hooks/useEvidenceOverlap.ts
@@ -1,0 +1,80 @@
+"use client";
+
+import { useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useEvidenceStore } from "@/app/lib/stores/evidenceStore";
+import { fetchApi } from "@/app/lib/formalization/api";
+import {
+  serializeTargetKey,
+  REVIEW_STUDY_TYPES,
+  type EvidenceArtifactType,
+  type EvidenceOverlapResponse,
+} from "@/app/lib/types/evidence";
+
+/**
+ * Hook for analyzing overlap between review papers and individual studies
+ * in an evidence slot.
+ *
+ * Only meaningful after papers have been scored (Phase 2), since overlap
+ * detection needs studyType to identify reviews. Returns early if the
+ * slot has no review-type papers.
+ */
+export function useEvidenceOverlap(
+  artifactType: EvidenceArtifactType,
+  elementId: string,
+) {
+  const key = serializeTargetKey({ artifactType, elementId });
+  const { slot, overlap, isAnalyzing, error } = useEvidenceStore(
+    useShallow((s) => ({
+      slot: s.slots[key],
+      overlap: s.overlap[key] ?? null,
+      isAnalyzing: s.analyzing[key] ?? false,
+      error: s.errors[key] ?? null,
+    })),
+  );
+
+  // Check whether the slot has any review-type papers (only meaningful when scored)
+  const hasReviews =
+    slot?.scored === true &&
+    slot.papers.some(
+      (p) =>
+        p.reliability?.studyType &&
+        (REVIEW_STUDY_TYPES as readonly string[]).includes(p.reliability.studyType),
+    );
+
+  const analyze = useCallback(async () => {
+    const { setAnalyzing, applyOverlap, setError } = useEvidenceStore.getState();
+    const currentSlot = useEvidenceStore.getState().slots[key];
+    if (!currentSlot || !currentSlot.scored || currentSlot.papers.length === 0) return;
+    // Guard against concurrent calls
+    if (useEvidenceStore.getState().analyzing[key]) return;
+
+    setAnalyzing(key, true);
+    setError(key, null);
+    try {
+      const result = await fetchApi<EvidenceOverlapResponse>(
+        "/api/evidence-overlap",
+        {
+          papers: currentSlot.papers.map((p) => ({
+            openAlexId: p.openAlexId,
+            title: p.title,
+            year: p.year,
+            abstract: p.abstract,
+            reliability: p.reliability,
+          })),
+        },
+      );
+      applyOverlap(key, result.analysis);
+    } catch (err) {
+      console.error("[useEvidenceOverlap]", err);
+      const message = err instanceof Error ? err.message : "Overlap analysis failed";
+      setError(key, message);
+    } finally {
+      useEvidenceStore.getState().setAnalyzing(key, false);
+    }
+  }, [key]);
+
+  const hasOverlap = overlap !== null;
+
+  return { slot, overlap, isAnalyzing, error, analyze, hasOverlap, hasReviews };
+}

--- a/app/hooks/useEvidenceOverlap.ts
+++ b/app/hooks/useEvidenceOverlap.ts
@@ -6,7 +6,7 @@ import { useEvidenceStore } from "@/app/lib/stores/evidenceStore";
 import { fetchApi } from "@/app/lib/formalization/api";
 import {
   serializeTargetKey,
-  REVIEW_STUDY_TYPES,
+  isReviewType,
   type EvidenceArtifactType,
   type EvidenceOverlapResponse,
 } from "@/app/lib/types/evidence";
@@ -36,11 +36,7 @@ export function useEvidenceOverlap(
   // Check whether the slot has any review-type papers (only meaningful when scored)
   const hasReviews =
     slot?.scored === true &&
-    slot.papers.some(
-      (p) =>
-        p.reliability?.studyType &&
-        (REVIEW_STUDY_TYPES as readonly string[]).includes(p.reliability.studyType),
-    );
+    slot.papers.some((p) => isReviewType(p.reliability?.studyType));
 
   const analyze = useCallback(async () => {
     const { setAnalyzing, applyOverlap, setError } = useEvidenceStore.getState();
@@ -50,7 +46,7 @@ export function useEvidenceOverlap(
     if (useEvidenceStore.getState().analyzing[key]) return;
 
     setAnalyzing(key, true);
-    setError(key, null);
+    if (useEvidenceStore.getState().errors[key]) setError(key, null);
     try {
       const result = await fetchApi<EvidenceOverlapResponse>(
         "/api/evidence-overlap",

--- a/app/lib/stores/evidenceStore.ts
+++ b/app/lib/stores/evidenceStore.ts
@@ -165,10 +165,25 @@ export const useEvidenceStore = create<EvidenceState & EvidenceActions>()(
       clearEvidence: (key: string) =>
         set((state: EvidenceState) => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { [key]: _removed, ...rest } = state.slots;
+          const { [key]: _s, ...restSlots } = state.slots;
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { [key]: _removedOverlap, ...restOverlap } = state.overlap;
-          return { slots: rest, overlap: restOverlap };
+          const { [key]: _o, ...restOverlap } = state.overlap;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [key]: _l, ...restLoading } = state.loading;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [key]: _sc, ...restScoring } = state.scoring;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [key]: _a, ...restAnalyzing } = state.analyzing;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [key]: _e, ...restErrors } = state.errors;
+          return {
+            slots: restSlots,
+            overlap: restOverlap,
+            loading: restLoading,
+            scoring: restScoring,
+            analyzing: restAnalyzing,
+            errors: restErrors,
+          };
         }),
 
       clearAll: () => set({ slots: {}, overlap: {}, loading: {}, scoring: {}, analyzing: {}, errors: {} }),

--- a/app/lib/stores/evidenceStore.ts
+++ b/app/lib/stores/evidenceStore.ts
@@ -11,7 +11,7 @@
 
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
-import type { EvidenceSlot, PaperScore } from "@/app/lib/types/evidence";
+import type { EvidenceSlot, PaperScore, OverlapAnalysis } from "@/app/lib/types/evidence";
 
 // ---------------------------------------------------------------------------
 // Debounced localStorage adapter (same pattern as workspaceStore)
@@ -54,10 +54,14 @@ const debouncedStorage = createDebouncedStorage();
 interface EvidenceState {
   /** Evidence slots keyed by "artifactType::elementId" */
   slots: Record<string, EvidenceSlot>;
+  /** Per-element overlap analysis results */
+  overlap: Record<string, OverlapAnalysis>;
   /** Per-element loading state (search or scoring) */
   loading: Record<string, boolean>;
   /** Per-element scoring loading state */
   scoring: Record<string, boolean>;
+  /** Per-element overlap analysis loading state */
+  analyzing: Record<string, boolean>;
   /** Per-element error messages */
   errors: Record<string, string>;
 }
@@ -66,17 +70,22 @@ interface EvidenceActions {
   setEvidence: (key: string, slot: EvidenceSlot) => void;
   setLoading: (key: string, loading: boolean) => void;
   setScoring: (key: string, scoring: boolean) => void;
+  setAnalyzing: (key: string, analyzing: boolean) => void;
   setError: (key: string, error: string | null) => void;
   /** Apply LLM scores to papers in a slot */
   applyScores: (key: string, scores: PaperScore[]) => void;
+  /** Apply overlap analysis results */
+  applyOverlap: (key: string, analysis: OverlapAnalysis) => void;
   clearEvidence: (key: string) => void;
   clearAll: () => void;
 }
 
 const DEFAULT_STATE: EvidenceState = {
   slots: {},
+  overlap: {},
   loading: {},
   scoring: {},
+  analyzing: {},
   errors: {},
 };
 
@@ -102,6 +111,11 @@ export const useEvidenceStore = create<EvidenceState & EvidenceActions>()(
       setScoring: (key: string, scoring: boolean) =>
         set((state: EvidenceState) => ({
           scoring: { ...state.scoring, [key]: scoring },
+        })),
+
+      setAnalyzing: (key: string, analyzing: boolean) =>
+        set((state: EvidenceState) => ({
+          analyzing: { ...state.analyzing, [key]: analyzing },
         })),
 
       setError: (key: string, error: string | null) =>
@@ -143,22 +157,29 @@ export const useEvidenceStore = create<EvidenceState & EvidenceActions>()(
           };
         }),
 
+      applyOverlap: (key: string, analysis: OverlapAnalysis) =>
+        set((state: EvidenceState) => ({
+          overlap: { ...state.overlap, [key]: analysis },
+        })),
+
       clearEvidence: (key: string) =>
         set((state: EvidenceState) => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { [key]: _removed, ...rest } = state.slots;
-          return { slots: rest };
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [key]: _removedOverlap, ...restOverlap } = state.overlap;
+          return { slots: rest, overlap: restOverlap };
         }),
 
-      clearAll: () => set({ slots: {}, loading: {}, scoring: {}, errors: {} }),
+      clearAll: () => set({ slots: {}, overlap: {}, loading: {}, scoring: {}, analyzing: {}, errors: {} }),
     }),
     {
       name: "evidence-store-v1",
       storage: typeof window !== "undefined"
         ? createJSONStorage(() => debouncedStorage)
         : undefined,
-      // Only persist slots, not transient loading state
-      partialize: (state: EvidenceState & EvidenceActions) => ({ slots: state.slots }),
+      // Only persist slots and overlap, not transient loading state
+      partialize: (state: EvidenceState & EvidenceActions) => ({ slots: state.slots, overlap: state.overlap }),
       skipHydration: true,
     },
   ),

--- a/app/lib/types/evidence.ts
+++ b/app/lib/types/evidence.ts
@@ -144,3 +144,56 @@ export type PaperScore = {
 export type EvidenceScoreResponse = {
   scores: PaperScore[];
 };
+
+// ---------------------------------------------------------------------------
+// Overlap and subsumption detection (Phase 3)
+// ---------------------------------------------------------------------------
+
+/** A detected containment relationship between a review paper and an individual study */
+export type SubsumptionRelation = {
+  /** OpenAlex ID of the review/meta-analysis */
+  reviewId: string;
+  /** OpenAlex ID of the individual study */
+  studyId: string;
+  /** How the relationship was detected */
+  detectionMethod: "citation-graph" | "llm-fallback";
+  /** Confidence in the relationship (0-1) */
+  confidence: number;
+};
+
+/** Status of a paper relative to reviews in the same evidence slot */
+export type PaperOverlapStatus =
+  | "subsumed"    // Study is included in a review within the result set
+  | "novel"       // Study is newer than the review(s) or not included
+  | "review"      // This paper IS a review/meta-analysis
+  | "no-reviews"; // No reviews in the set to compare against
+
+/** Study types that count as "review" papers for overlap detection */
+export const REVIEW_STUDY_TYPES: readonly StudyType[] = [
+  "meta-analysis",
+  "systematic-review",
+] as const;
+
+/** Overlap analysis result for an evidence slot */
+export type OverlapAnalysis = {
+  /** All detected containment relationships */
+  relations: SubsumptionRelation[];
+  /** Per-paper status keyed by openAlexId */
+  paperStatus: Record<string, PaperOverlapStatus>;
+  /** When analysis was performed */
+  analyzedAt: string;
+};
+
+/** API request shape for overlap analysis */
+export type EvidenceOverlapRequest = {
+  /** Papers to analyze — must have reliability scores with studyType */
+  papers: Pick<
+    EvidencePaper,
+    "openAlexId" | "title" | "year" | "abstract" | "reliability"
+  >[];
+};
+
+/** API response shape for overlap analysis */
+export type EvidenceOverlapResponse = {
+  analysis: OverlapAnalysis;
+};

--- a/app/lib/types/evidence.ts
+++ b/app/lib/types/evidence.ts
@@ -174,6 +174,11 @@ export const REVIEW_STUDY_TYPES: readonly StudyType[] = [
   "systematic-review",
 ] as const;
 
+/** Check whether a study type is a review type (meta-analysis or systematic-review) */
+export function isReviewType(studyType: string | undefined | null): boolean {
+  return !!studyType && (REVIEW_STUDY_TYPES as readonly string[]).includes(studyType);
+}
+
 /** Overlap analysis result for an evidence slot */
 export type OverlapAnalysis = {
   /** All detected containment relationships */


### PR DESCRIPTION
## Summary

- **Phase 1**: Evidence slot model + OpenAlex search. Users can trigger evidence search from statistical model and counterexample panels, finding relevant academic papers via LLM-generated queries and OpenAlex's free API.
- **Phase 2**: LLM-based reliability and relatedness scoring. Papers are assessed for study type, methodology quality, red flags, and relevance to the specific claim. Scores shown as color-coded badges.
- **Phase 3**: Overlap and subsumption detection. Detects when review papers (meta-analyses, systematic reviews) already cover individual studies in the same result set. Uses OpenAlex's citation graph (referenced_works) as primary signal with LLM abstract comparison as fallback for unmatched pairs. Papers annotated as "Review paper", "Included in review", or "Novel" with colored badges.

## Key architecture decisions

- Evidence is metadata *about* artifacts, not an artifact itself — stored in a separate Zustand store (`evidenceStore`), not in artifact versioning
- Each phase is a separate user-triggered step (search → score → check overlap), giving users control over LLM token spend
- OpenAlex used for all search and citation graph queries (free, no API key beyond `OPENALEX_MAILTO`)
- Overlap shown as badges and grouping in the existing flat card list, not as a graph widget

## Files added (Phase 3 specifically)

- `app/api/evidence-overlap/route.ts` — API route for overlap analysis
- `app/api/evidence-overlap/overlapUtils.ts` — Pure utility functions for partition, relation building, status derivation
- `app/api/evidence-overlap/overlapUtils.test.ts` — 16 unit tests
- `app/hooks/useEvidenceOverlap.ts` — React hook
- `app/components/features/evidence-search/OverlapSummary.tsx` — Summary bar component

## How to test

1. Set `OPENALEX_MAILTO` and `ANTHROPIC_API_KEY` env vars
2. `npm run dev`, open a statistical model or counterexamples panel
3. Click "Find evidence" → papers appear
4. Click "Score papers" → reliability/relatedness badges appear
5. If any papers are scored as meta-analysis or systematic review, "Check overlap" button appears
6. Click "Check overlap" → papers annotated with Review/Subsumed/Novel badges, summary bar shows counts

## Areas of uncertainty

- LLM fallback for overlap detection is best-effort — if abstract comparison is unreliable for specialized domains, it degrades gracefully (falls back to citation-graph-only results)
- OpenAlex's `referenced_works` coverage varies — some papers may have incomplete reference lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)