### PR TITLE
feat: Phase 4 — assisted evidence integration with approve/reject proposals

### DIFF
--- a/app/api/evidence-integrate/integrateValidation.test.ts
+++ b/app/api/evidence-integrate/integrateValidation.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { validateProposal } from "./integrateValidation";
+
+const ARTIFACT = {
+  summary: "A study of X",
+  hypotheses: [
+    { id: "H1", statement: "X causes Y", nullHypothesis: "no effect", testSuggestion: "t-test" },
+  ],
+  assumptions: ["normality", "independence"],
+};
+
+const VALID_IDS = new Set(["W1", "W2", "W3"]);
+
+function rawProposal(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    fieldPath: "summary",
+    fieldLabel: "Summary",
+    currentValue: "A study of X",
+    proposedValue: "A study of X and Y",
+    rationale: "Paper W1 shows Y is also relevant",
+    paperIds: ["W1"],
+    editType: "refine-wording",
+    ...overrides,
+  };
+}
+
+describe("validateProposal", () => {
+  it("returns a valid proposal unchanged", () => {
+    const result = validateProposal(rawProposal(), ARTIFACT, VALID_IDS);
+    expect(result).toEqual({
+      fieldPath: "summary",
+      fieldLabel: "Summary",
+      currentValue: "A study of X",
+      proposedValue: "A study of X and Y",
+      rationale: "Paper W1 shows Y is also relevant",
+      paperIds: ["W1"],
+      editType: "refine-wording",
+    });
+  });
+
+  it("returns null when fieldPath is missing", () => {
+    expect(validateProposal(rawProposal({ fieldPath: "" }), ARTIFACT, VALID_IDS)).toBeNull();
+  });
+
+  it("returns null when fieldPath does not resolve", () => {
+    expect(validateProposal(rawProposal({ fieldPath: "nonexistent" }), ARTIFACT, VALID_IDS)).toBeNull();
+  });
+
+  it("returns null when currentValue equals proposedValue", () => {
+    expect(
+      validateProposal(rawProposal({ proposedValue: "A study of X" }), ARTIFACT, VALID_IDS),
+    ).toBeNull();
+  });
+
+  it("returns null when paperIds is empty", () => {
+    expect(validateProposal(rawProposal({ paperIds: [] }), ARTIFACT, VALID_IDS)).toBeNull();
+  });
+
+  it("filters out invalid paperIds", () => {
+    const result = validateProposal(
+      rawProposal({ paperIds: ["W1", "INVALID", "W2"] }),
+      ARTIFACT,
+      VALID_IDS,
+    );
+    expect(result?.paperIds).toEqual(["W1", "W2"]);
+  });
+
+  it("returns null when all paperIds are invalid", () => {
+    expect(
+      validateProposal(rawProposal({ paperIds: ["INVALID"] }), ARTIFACT, VALID_IDS),
+    ).toBeNull();
+  });
+
+  it("defaults to refine-wording for invalid editType", () => {
+    const result = validateProposal(rawProposal({ editType: "unknown-type" }), ARTIFACT, VALID_IDS);
+    expect(result?.editType).toBe("refine-wording");
+  });
+
+  it("accepts all valid edit types", () => {
+    for (const editType of ["update-prior", "add-evidence", "flag-contradiction", "refine-wording"]) {
+      const result = validateProposal(rawProposal({ editType }), ARTIFACT, VALID_IDS);
+      expect(result?.editType).toBe(editType);
+    }
+  });
+
+  it("validates nested fieldPaths", () => {
+    const result = validateProposal(
+      rawProposal({
+        fieldPath: "hypotheses[0].statement",
+        currentValue: "X causes Y",
+        proposedValue: "X strongly causes Y (d=0.4)",
+      }),
+      ARTIFACT,
+      VALID_IDS,
+    );
+    expect(result?.fieldPath).toBe("hypotheses[0].statement");
+  });
+
+  it("returns null for non-string required fields", () => {
+    expect(validateProposal(rawProposal({ fieldLabel: 123 }), ARTIFACT, VALID_IDS)).toBeNull();
+    expect(validateProposal(rawProposal({ rationale: null }), ARTIFACT, VALID_IDS)).toBeNull();
+    expect(validateProposal(rawProposal({ proposedValue: undefined }), ARTIFACT, VALID_IDS)).toBeNull();
+  });
+});

--- a/app/api/evidence-integrate/integrateValidation.ts
+++ b/app/api/evidence-integrate/integrateValidation.ts
@@ -1,0 +1,75 @@
+/**
+ * Validation helpers for LLM-generated integration proposals.
+ *
+ * Extracted from the route handler so they can be unit-tested independently.
+ */
+
+import { resolveFieldPath } from "@/app/lib/utils/applyProposals";
+import type { IntegrationEditType, RawIntegrationProposal } from "@/app/lib/types/evidence";
+
+const VALID_EDIT_TYPES: readonly string[] = [
+  "update-prior",
+  "add-evidence",
+  "flag-contradiction",
+  "refine-wording",
+];
+
+/**
+ * Validate a single raw proposal from LLM output.
+ *
+ * @param raw - The raw proposal object from the LLM
+ * @param artifact - The parsed artifact object (to verify fieldPath)
+ * @param validPaperIds - Set of openAlexIds from the request papers
+ * @returns A validated RawIntegrationProposal, or null if invalid
+ */
+export function validateProposal(
+  raw: Record<string, unknown>,
+  artifact: Record<string, unknown>,
+  validPaperIds: Set<string>,
+): RawIntegrationProposal | null {
+  // Required string fields
+  const fieldPath = raw.fieldPath;
+  const fieldLabel = raw.fieldLabel;
+  const currentValue = raw.currentValue;
+  const proposedValue = raw.proposedValue;
+  const rationale = raw.rationale;
+
+  if (
+    typeof fieldPath !== "string" || !fieldPath ||
+    typeof fieldLabel !== "string" || !fieldLabel ||
+    typeof currentValue !== "string" ||
+    typeof proposedValue !== "string" ||
+    typeof rationale !== "string"
+  ) {
+    return null;
+  }
+
+  // proposedValue must differ from currentValue
+  if (currentValue === proposedValue) return null;
+
+  // fieldPath must resolve to an existing field in the artifact
+  if (!resolveFieldPath(artifact, fieldPath)) return null;
+
+  // paperIds must be a non-empty array of valid IDs
+  const paperIds = raw.paperIds;
+  if (!Array.isArray(paperIds) || paperIds.length === 0) return null;
+  const filteredPaperIds = (paperIds as unknown[]).filter(
+    (id): id is string => typeof id === "string" && validPaperIds.has(id),
+  );
+  if (filteredPaperIds.length === 0) return null;
+
+  // editType must be valid
+  const editType = typeof raw.editType === "string" && VALID_EDIT_TYPES.includes(raw.editType)
+    ? (raw.editType as IntegrationEditType)
+    : "refine-wording";
+
+  return {
+    fieldPath,
+    fieldLabel,
+    currentValue,
+    proposedValue,
+    rationale,
+    paperIds: filteredPaperIds,
+    editType,
+  };
+}

--- a/app/api/evidence-integrate/route.ts
+++ b/app/api/evidence-integrate/route.ts
@@ -1,0 +1,247 @@
+/**
+ * API route for generating evidence-based artifact edit proposals.
+ *
+ * Takes an artifact (statistical-model or counterexamples) and scored papers,
+ * returns surgical edit proposals that the user can approve or reject.
+ * This is Phase 4 of the evidence grounding architecture.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { callLlm, OpenRouterError } from "@/app/lib/llm/callLlm";
+import { CLAUDE_SONNET } from "@/app/lib/llm/models";
+import { stripCodeFences } from "@/app/lib/utils/stripCodeFences";
+import {
+  MAX_INTEGRATION_PAPERS,
+  type EvidenceArtifactType,
+  type EvidenceIntegrateRequest,
+  type EvidenceIntegrateResponse,
+  type RawIntegrationProposal,
+} from "@/app/lib/types/evidence";
+import { validateProposal } from "./integrateValidation";
+const MAX_ARTIFACT_LENGTH = 10000;
+
+// ---------------------------------------------------------------------------
+// Artifact schema descriptions (so the LLM knows valid fieldPaths)
+// ---------------------------------------------------------------------------
+
+const SCHEMA_DESCRIPTIONS: Record<EvidenceArtifactType, string> = {
+  "statistical-model": `The artifact is a statistical model with this structure:
+{
+  "summary": "string",
+  "variables": [{ "id": "string", "label": "string", "role": "independent|dependent|confounding|control", "distribution": "string (optional)" }],
+  "hypotheses": [{ "id": "string", "statement": "string", "nullHypothesis": "string", "testSuggestion": "string" }],
+  "assumptions": ["string", ...],
+  "sampleRequirements": "string (optional)"
+}
+
+Valid fieldPaths include:
+- "summary" — the overall model summary
+- "variables[i].distribution" — a variable's assumed distribution
+- "hypotheses[i].statement" — a hypothesis statement
+- "hypotheses[i].nullHypothesis" — a null hypothesis
+- "hypotheses[i].testSuggestion" — the suggested statistical test
+- "assumptions[i]" — an individual assumption
+- "sampleRequirements" — sample size/requirements description`,
+
+  counterexamples: `The artifact is a counterexamples analysis with this structure:
+{
+  "claim": "string",
+  "counterexamples": [{ "id": "string", "scenario": "string", "targetAssumption": "string", "explanation": "string", "plausibility": "high|medium|low" }],
+  "robustnessAssessment": "string",
+  "summary": "string"
+}
+
+Valid fieldPaths include:
+- "claim" — the claim being tested
+- "counterexamples[i].scenario" — a counterexample scenario
+- "counterexamples[i].explanation" — why the counterexample works
+- "counterexamples[i].plausibility" — plausibility rating (high/medium/low)
+- "robustnessAssessment" — overall robustness assessment
+- "summary" — the analysis summary`,
+};
+
+// ---------------------------------------------------------------------------
+// LLM prompt
+// ---------------------------------------------------------------------------
+
+const INTEGRATE_SYSTEM_PROMPT = `You propose specific, surgical edits to a structured artifact based on evidence from academic papers.
+
+Your task:
+1. Read the artifact content carefully
+2. Read the evidence papers (titles, abstracts, scores)
+3. Identify 2-5 specific fields in the artifact that should be updated based on the evidence
+4. For each, propose a concrete replacement value
+
+Rules:
+- Each proposal must target ONE specific field via its fieldPath
+- The currentValue MUST exactly match what is currently in the artifact at that fieldPath
+- The proposedValue should be a concrete replacement, not a suggestion to "consider" something
+- Keep proposed changes proportional — update the specific text, don't rewrite entire sections
+- Reference specific findings from the papers (effect sizes, sample sizes, conclusions)
+- Prioritize high-reliability and high-relatedness papers
+- If a paper contradicts a claim, use editType "flag-contradiction"
+- If a paper provides specific numbers to update, use editType "update-prior"
+- If a paper supports/strengthens a claim, use editType "add-evidence"
+- For general improvements in precision, use editType "refine-wording"
+
+Return a JSON object with this exact shape:
+{
+  "proposals": [
+    {
+      "fieldPath": "hypotheses[0].statement",
+      "fieldLabel": "Hypothesis H1",
+      "currentValue": "X causes Y",
+      "proposedValue": "X causes Y with moderate effect (d=0.4, based on Smith et al. 2023 meta-analysis)",
+      "rationale": "Smith et al. (2023) meta-analysis of 12 RCTs found a consistent moderate effect (d=0.4, 95% CI [0.2, 0.6]).",
+      "paperIds": ["W12345"],
+      "editType": "update-prior"
+    }
+  ]
+}`;
+
+const INTEGRATE_SCHEMA = {
+  type: "json_schema" as const,
+  json_schema: {
+    name: "integration_proposals",
+    strict: true,
+    schema: {
+      type: "object",
+      required: ["proposals"],
+      additionalProperties: false,
+      properties: {
+        proposals: {
+          type: "array",
+          items: {
+            type: "object",
+            required: [
+              "fieldPath",
+              "fieldLabel",
+              "currentValue",
+              "proposedValue",
+              "rationale",
+              "paperIds",
+              "editType",
+            ],
+            additionalProperties: false,
+            properties: {
+              fieldPath: { type: "string" },
+              fieldLabel: { type: "string" },
+              currentValue: { type: "string" },
+              proposedValue: { type: "string" },
+              rationale: { type: "string" },
+              paperIds: { type: "array", items: { type: "string" } },
+              editType: {
+                type: "string",
+                enum: ["update-prior", "add-evidence", "flag-contradiction", "refine-wording"],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as Partial<EvidenceIntegrateRequest>;
+
+    // Validate request
+    if (!body.artifactType || !(body.artifactType in SCHEMA_DESCRIPTIONS)) {
+      return NextResponse.json({ error: "artifactType must be 'statistical-model' or 'counterexamples'" }, { status: 400 });
+    }
+    if (!body.artifactContent || typeof body.artifactContent !== "string") {
+      return NextResponse.json({ error: "artifactContent is required" }, { status: 400 });
+    }
+    if (!Array.isArray(body.papers) || body.papers.length === 0) {
+      return NextResponse.json({ error: "papers array is required and must not be empty" }, { status: 400 });
+    }
+    if (body.papers.length > MAX_INTEGRATION_PAPERS) {
+      return NextResponse.json({ error: `Too many papers (max ${MAX_INTEGRATION_PAPERS})` }, { status: 400 });
+    }
+
+    // Parse and validate artifact content
+    let artifact: Record<string, unknown>;
+    try {
+      artifact = JSON.parse(body.artifactContent.slice(0, MAX_ARTIFACT_LENGTH));
+    } catch {
+      return NextResponse.json({ error: "artifactContent is not valid JSON" }, { status: 400 });
+    }
+
+    const validPaperIds = new Set(body.papers.map((p) => p.openAlexId));
+
+    // Build user message
+    const paperSummaries = body.papers.map((p, i) => {
+      const parts = [`Paper ${i + 1} (ID: ${p.openAlexId}):`];
+      parts.push(`  Title: ${p.title}`);
+      if (p.year) parts.push(`  Year: ${p.year}`);
+      if (p.reliability) {
+        parts.push(`  Study type: ${p.reliability.studyType}`);
+        parts.push(`  Reliability score: ${p.reliability.score.toFixed(2)}`);
+      }
+      if (p.relatedness) {
+        parts.push(`  Relatedness score: ${p.relatedness.score.toFixed(2)}`);
+      }
+      if (p.abstract) parts.push(`  Abstract: ${String(p.abstract).slice(0, 500)}`);
+      else parts.push("  Abstract: (not available)");
+      return parts.join("\n");
+    });
+
+    const userMessage = `${SCHEMA_DESCRIPTIONS[body.artifactType]}
+
+Current artifact content:
+${body.artifactContent.slice(0, MAX_ARTIFACT_LENGTH)}
+
+Evidence papers:
+${paperSummaries.join("\n\n")}
+
+Propose 2-5 specific edits to the artifact based on these papers.`;
+
+    const { text } = await callLlm({
+      endpoint: "evidence-integrate",
+      systemPrompt: INTEGRATE_SYSTEM_PROMPT,
+      userContent: userMessage,
+      maxTokens: 4096,
+      openRouterModel: CLAUDE_SONNET,
+      responseFormat: INTEGRATE_SCHEMA,
+    });
+
+    if (!text) {
+      // No API key — return empty proposals
+      return NextResponse.json({ proposals: [] } satisfies EvidenceIntegrateResponse);
+    }
+
+    // Parse and validate LLM response
+    const parsed = JSON.parse(stripCodeFences(text));
+    if (!Array.isArray(parsed.proposals)) {
+      return NextResponse.json({ error: "Invalid LLM response format" }, { status: 502 });
+    }
+
+    const proposals: RawIntegrationProposal[] = [];
+    for (const raw of parsed.proposals) {
+      const validated = validateProposal(
+        raw as Record<string, unknown>,
+        artifact,
+        validPaperIds,
+      );
+      if (validated) proposals.push(validated);
+    }
+
+    const response: EvidenceIntegrateResponse = { proposals };
+    return NextResponse.json(response);
+  } catch (err) {
+    if (err instanceof OpenRouterError) {
+      return NextResponse.json(
+        { error: err.message, details: err.details },
+        { status: 502 },
+      );
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.error("[evidence-integrate] Error:", message);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/evidence-integrate/route.ts
+++ b/app/api/evidence-integrate/route.ts
@@ -46,16 +46,16 @@ Valid fieldPaths include:
   counterexamples: `The artifact is a counterexamples analysis with this structure:
 {
   "claim": "string",
-  "counterexamples": [{ "id": "string", "scenario": "string", "targetAssumption": "string", "explanation": "string", "plausibility": "high|medium|low" }],
+  "scenarios": [{ "id": "string", "scenario": "string", "targetAssumption": "string", "explanation": "string", "plausibility": "high|medium|low" }],
   "robustnessAssessment": "string",
   "summary": "string"
 }
 
 Valid fieldPaths include:
 - "claim" — the claim being tested
-- "counterexamples[i].scenario" — a counterexample scenario
-- "counterexamples[i].explanation" — why the counterexample works
-- "counterexamples[i].plausibility" — plausibility rating (high/medium/low)
+- "scenarios[i].scenario" — a counterexample scenario
+- "scenarios[i].explanation" — why the counterexample works
+- "scenarios[i].plausibility" — plausibility rating (high/medium/low)
 - "robustnessAssessment" — overall robustness assessment
 - "summary" — the analysis summary`,
 };

--- a/app/components/features/evidence-search/FindEvidenceButton.tsx
+++ b/app/components/features/evidence-search/FindEvidenceButton.tsx
@@ -33,8 +33,8 @@ export default function FindEvidenceButton({
   const { isScoring, score } = useEvidenceScoring(artifactType, elementId);
   const { overlap, isAnalyzing, analyze, hasReviews } = useEvidenceOverlap(artifactType, elementId);
   const {
-    proposals, isIntegrating, integrate, setDecision,
-    hasProposals, canIntegrate,
+    proposals, isIntegrating, error: integrationError, integrate, setDecision,
+    clearProposals, hasProposals, canIntegrate,
   } = useEvidenceIntegration(artifactType, elementId);
 
   const canSuggestEdits = canIntegrate && !!artifactJson && !!onContentChange;
@@ -43,7 +43,8 @@ export default function FindEvidenceButton({
     if (!artifactJson || !onContentChange || proposals.length === 0) return;
     const updated = applyProposals(artifactJson, proposals);
     onContentChange(updated);
-  }, [artifactJson, onContentChange, proposals]);
+    clearProposals();
+  }, [artifactJson, onContentChange, proposals, clearProposals]);
 
   return (
     <div className="mt-1.5">
@@ -89,6 +90,10 @@ export default function FindEvidenceButton({
               ? "Re-suggest edits"
               : "Suggest edits"}
         </button>
+      )}
+
+      {integrationError && (
+        <p className="text-xs text-red-600 mt-1">{integrationError}</p>
       )}
 
       {hasProposals && slot && (

--- a/app/components/features/evidence-search/FindEvidenceButton.tsx
+++ b/app/components/features/evidence-search/FindEvidenceButton.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import { useCallback } from "react";
 import { useEvidenceSearch } from "@/app/hooks/useEvidenceSearch";
 import { useEvidenceScoring } from "@/app/hooks/useEvidenceScoring";
 import { useEvidenceOverlap } from "@/app/hooks/useEvidenceOverlap";
+import { useEvidenceIntegration } from "@/app/hooks/useEvidenceIntegration";
+import { applyProposals } from "@/app/lib/utils/applyProposals";
 import EvidenceResultsSection from "./EvidenceResultsSection";
+import IntegrationProposalsSection from "./IntegrationProposalsSection";
 import type { EvidenceArtifactType } from "@/app/lib/types/evidence";
 
 type FindEvidenceButtonProps = {
@@ -11,6 +15,10 @@ type FindEvidenceButtonProps = {
   elementId: string;
   elementContent: string;
   contextSummary?: string;
+  /** Full artifact content as JSON string (needed for integration proposals) */
+  artifactJson?: string;
+  /** Callback to apply artifact changes (needed to apply approved proposals) */
+  onContentChange?: (json: string) => void;
 };
 
 export default function FindEvidenceButton({
@@ -18,10 +26,24 @@ export default function FindEvidenceButton({
   elementId,
   elementContent,
   contextSummary,
+  artifactJson,
+  onContentChange,
 }: FindEvidenceButtonProps) {
   const { slot, isLoading, error, search } = useEvidenceSearch(artifactType, elementId);
   const { isScoring, score } = useEvidenceScoring(artifactType, elementId);
   const { overlap, isAnalyzing, analyze, hasReviews } = useEvidenceOverlap(artifactType, elementId);
+  const {
+    proposals, isIntegrating, integrate, setDecision,
+    hasProposals, canIntegrate,
+  } = useEvidenceIntegration(artifactType, elementId);
+
+  const canSuggestEdits = canIntegrate && !!artifactJson && !!onContentChange;
+
+  const handleApplyApproved = useCallback(() => {
+    if (!artifactJson || !onContentChange || proposals.length === 0) return;
+    const updated = applyProposals(artifactJson, proposals);
+    onContentChange(updated);
+  }, [artifactJson, onContentChange, proposals]);
 
   return (
     <div className="mt-1.5">
@@ -51,6 +73,30 @@ export default function FindEvidenceButton({
           isAnalyzing={isAnalyzing}
           overlap={overlap}
           hasReviews={hasReviews}
+        />
+      )}
+
+      {slot && canSuggestEdits && (
+        <button
+          type="button"
+          disabled={isIntegrating}
+          onClick={() => integrate(artifactJson)}
+          className="mt-1.5 text-xs text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded-md px-2 py-0.5 hover:bg-[#F5F1ED] disabled:opacity-50 disabled:cursor-wait"
+        >
+          {isIntegrating
+            ? "Generating suggestions..."
+            : hasProposals
+              ? "Re-suggest edits"
+              : "Suggest edits"}
+        </button>
+      )}
+
+      {hasProposals && slot && (
+        <IntegrationProposalsSection
+          proposals={proposals}
+          papers={slot.papers}
+          onSetDecision={setDecision}
+          onApplyApproved={handleApplyApproved}
         />
       )}
     </div>

--- a/app/components/features/evidence-search/FindEvidenceButton.tsx
+++ b/app/components/features/evidence-search/FindEvidenceButton.tsx
@@ -82,7 +82,7 @@ export default function FindEvidenceButton({
           type="button"
           disabled={isIntegrating}
           onClick={() => integrate(artifactJson)}
-          className="mt-1.5 text-xs text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded-md px-2 py-0.5 hover:bg-[#F5F1ED] disabled:opacity-50 disabled:cursor-wait"
+          className="mt-1.5 text-xs text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded-md px-2 py-0.5 hover:bg-[#F5F1ED] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ink-black)]/30 active:bg-[#ECE7E2] disabled:opacity-50 disabled:cursor-wait"
         >
           {isIntegrating
             ? "Generating suggestions..."

--- a/app/components/features/evidence-search/IntegrationProposalCard.tsx
+++ b/app/components/features/evidence-search/IntegrationProposalCard.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { IntegrationEditType, IntegrationProposal } from "@/app/lib/types/evidence";
+
+const EDIT_TYPE_STYLES: Record<IntegrationEditType, { label: string; className: string }> = {
+  "update-prior": { label: "Update prior", className: "text-blue-700 bg-blue-50 border-blue-200" },
+  "add-evidence": { label: "Add evidence", className: "text-green-700 bg-green-50 border-green-200" },
+  "flag-contradiction": { label: "Contradiction", className: "text-red-700 bg-red-50 border-red-200" },
+  "refine-wording": { label: "Refine wording", className: "text-gray-700 bg-gray-50 border-gray-200" },
+};
+
+export default function IntegrationProposalCard({
+  proposal,
+  paperTitles,
+  onApprove,
+  onReject,
+}: {
+  proposal: IntegrationProposal;
+  paperTitles: Record<string, string>;
+  onApprove: (id: string) => void;
+  onReject: (id: string) => void;
+}) {
+  const editStyle = EDIT_TYPE_STYLES[proposal.editType];
+  const decided = proposal.decision !== null;
+
+  return (
+    <div className={`rounded border px-3 py-2 space-y-2 ${
+      proposal.decision === true
+        ? "border-green-300 bg-green-50/30"
+        : proposal.decision === false
+          ? "border-[#DDD9D5] bg-[#F5F1ED]/50 opacity-60"
+          : "border-[#DDD9D5] bg-white"
+    }`}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-medium text-[var(--ink-black)]">
+          {proposal.fieldLabel}
+        </span>
+        <span className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-mono ${editStyle.className}`}>
+          {editStyle.label}
+        </span>
+      </div>
+
+      <div className="space-y-1">
+        <div className="rounded bg-red-50 border border-red-200 px-2 py-1">
+          <span className="text-[10px] font-mono text-red-500 mr-1">-</span>
+          <span className="text-xs text-red-800 line-through">{proposal.currentValue}</span>
+        </div>
+        <div className="rounded bg-green-50 border border-green-200 px-2 py-1">
+          <span className="text-[10px] font-mono text-green-500 mr-1">+</span>
+          <span className="text-xs text-green-800">{proposal.proposedValue}</span>
+        </div>
+      </div>
+
+      <p className="text-xs text-[#6B6560] leading-relaxed">{proposal.rationale}</p>
+
+      {proposal.paperIds.length > 0 && (
+        <div className="text-[10px] text-[#9A9590]">
+          Based on: {proposal.paperIds.map((id, i) => (
+            <span key={id}>
+              {i > 0 && ", "}
+              {paperTitles[id] ?? id}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        {decided ? (
+          <span className={`text-xs font-medium ${
+            proposal.decision ? "text-green-700" : "text-[#9A9590]"
+          }`}>
+            {proposal.decision ? "Approved" : "Rejected"}
+          </span>
+        ) : (
+          <>
+            <button
+              type="button"
+              onClick={() => onApprove(proposal.id)}
+              className="text-[10px] font-medium text-green-700 hover:text-green-900 border border-green-300 rounded px-2 py-0.5 hover:bg-green-50"
+            >
+              Approve
+            </button>
+            <button
+              type="button"
+              onClick={() => onReject(proposal.id)}
+              className="text-[10px] font-medium text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded px-2 py-0.5 hover:bg-[#F5F1ED]"
+            >
+              Reject
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/features/evidence-search/IntegrationProposalCard.tsx
+++ b/app/components/features/evidence-search/IntegrationProposalCard.tsx
@@ -32,10 +32,10 @@ export default function IntegrationProposalCard({
           : "border-[#DDD9D5] bg-white"
     }`}>
       <div className="flex items-center justify-between gap-2">
-        <span className="text-sm font-medium text-[var(--ink-black)]">
+        <span className="min-w-0 truncate text-sm font-medium text-[var(--ink-black)]">
           {proposal.fieldLabel}
         </span>
-        <span className={`inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-mono ${editStyle.className}`}>
+        <span className={`shrink-0 inline-flex items-center rounded border px-1.5 py-0.5 text-[10px] font-mono ${editStyle.className}`}>
           {editStyle.label}
         </span>
       </div>
@@ -76,14 +76,14 @@ export default function IntegrationProposalCard({
             <button
               type="button"
               onClick={() => onApprove(proposal.id)}
-              className="text-[10px] font-medium text-green-700 hover:text-green-900 border border-green-300 rounded px-2 py-0.5 hover:bg-green-50"
+              className="text-[10px] font-medium text-green-700 hover:text-green-900 border border-green-300 rounded px-2 py-0.5 hover:bg-green-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600/40 active:bg-green-100"
             >
               Approve
             </button>
             <button
               type="button"
               onClick={() => onReject(proposal.id)}
-              className="text-[10px] font-medium text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded px-2 py-0.5 hover:bg-[#F5F1ED]"
+              className="text-[10px] font-medium text-[#6B6560] hover:text-[var(--ink-black)] border border-[#DDD9D5] rounded px-2 py-0.5 hover:bg-[#F5F1ED] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ink-black)]/30 active:bg-[#ECE7E2]"
             >
               Reject
             </button>

--- a/app/components/features/evidence-search/IntegrationProposalsSection.tsx
+++ b/app/components/features/evidence-search/IntegrationProposalsSection.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { EvidencePaper, IntegrationProposal } from "@/app/lib/types/evidence";
+import IntegrationProposalCard from "./IntegrationProposalCard";
+
+type IntegrationProposalsSectionProps = {
+  proposals: IntegrationProposal[];
+  papers: EvidencePaper[];
+  onSetDecision: (id: string, decision: boolean) => void;
+  onApplyApproved: () => void;
+};
+
+export default function IntegrationProposalsSection({
+  proposals,
+  papers,
+  onSetDecision,
+  onApplyApproved,
+}: IntegrationProposalsSectionProps) {
+  const [open, setOpen] = useState(true);
+
+  const paperTitles = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const p of papers) {
+      map[p.openAlexId] = p.title;
+    }
+    return map;
+  }, [papers]);
+
+  const pendingCount = proposals.filter((p) => p.decision === null).length;
+  const approvedCount = proposals.filter((p) => p.decision === true).length;
+
+  return (
+    <div className="mt-2 border-t border-[#DDD9D5] pt-2">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1 text-xs font-medium text-[#6B6560] hover:text-[var(--ink-black)]"
+      >
+        <span className={`inline-block transition-transform ${open ? "rotate-90" : ""}`}>
+          &#9654;
+        </span>
+        {proposals.length} proposed edit{proposals.length === 1 ? "" : "s"}
+        {pendingCount > 0 && (
+          <span className="text-[10px] text-[#9A9590] ml-1">({pendingCount} pending)</span>
+        )}
+      </button>
+
+      {open && (
+        <div className="mt-2 space-y-2">
+          {proposals.map((p) => (
+            <IntegrationProposalCard
+              key={p.id}
+              proposal={p}
+              paperTitles={paperTitles}
+              onApprove={(id) => onSetDecision(id, true)}
+              onReject={(id) => onSetDecision(id, false)}
+            />
+          ))}
+
+          {approvedCount > 0 && (
+            <button
+              type="button"
+              onClick={onApplyApproved}
+              className="text-xs font-medium text-white bg-green-700 hover:bg-green-800 rounded px-3 py-1"
+            >
+              Apply {approvedCount} approved edit{approvedCount === 1 ? "" : "s"}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/features/evidence-search/IntegrationProposalsSection.tsx
+++ b/app/components/features/evidence-search/IntegrationProposalsSection.tsx
@@ -35,7 +35,7 @@ export default function IntegrationProposalsSection({
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="flex items-center gap-1 text-xs font-medium text-[#6B6560] hover:text-[var(--ink-black)]"
+        className="flex items-center gap-1 rounded text-xs font-medium text-[#6B6560] hover:text-[var(--ink-black)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ink-black)]/30"
       >
         <span className={`inline-block transition-transform ${open ? "rotate-90" : ""}`}>
           &#9654;
@@ -62,7 +62,7 @@ export default function IntegrationProposalsSection({
             <button
               type="button"
               onClick={onApplyApproved}
-              className="text-xs font-medium text-white bg-green-700 hover:bg-green-800 rounded px-3 py-1"
+              className="text-xs font-medium text-white bg-green-700 hover:bg-green-800 rounded px-3 py-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-600/50 active:bg-green-900"
             >
               Apply {approvedCount} approved edit{approvedCount === 1 ? "" : "s"}
             </button>

--- a/app/components/panels/CounterexamplesPanel.tsx
+++ b/app/components/panels/CounterexamplesPanel.tsx
@@ -26,6 +26,11 @@ export default function CounterexamplesPanel({
 }: CounterexamplesPanelProps) {
   const { updateField, updateArrayItem } = useFieldUpdaters(counterexamples, onContentChange);
 
+  const artifactJson = useMemo(
+    () => counterexamples ? JSON.stringify(counterexamples) : undefined,
+    [counterexamples],
+  );
+
   // Build search description from claim + top counterexample scenarios
   const evidenceSearchContent = useMemo(() => {
     if (!counterexamples) return "";
@@ -111,6 +116,8 @@ export default function CounterexamplesPanel({
                 artifactType="counterexamples"
                 elementId={WHOLE_ARTIFACT_ELEMENT_ID}
                 elementContent={evidenceSearchContent}
+                artifactJson={artifactJson}
+                onContentChange={onContentChange}
               />
             </section>
           )}

--- a/app/components/panels/CounterexamplesPanel.tsx
+++ b/app/components/panels/CounterexamplesPanel.tsx
@@ -34,6 +34,11 @@ export default function CounterexamplesPanel({
   const scenarios = getScenarios(counterexamples);
   const { updateField, updateArrayItem } = useFieldUpdaters(counterexamples, onContentChange);
 
+  const artifactJson = useMemo(
+    () => counterexamples ? JSON.stringify(counterexamples) : undefined,
+    [counterexamples],
+  );
+
   // Build search description from claim + top counterexample scenarios
   const evidenceSearchContent = useMemo(() => {
     if (!counterexamples) return "";
@@ -116,6 +121,8 @@ export default function CounterexamplesPanel({
                 artifactType="counterexamples"
                 elementId={WHOLE_ARTIFACT_ELEMENT_ID}
                 elementContent={evidenceSearchContent}
+                artifactJson={artifactJson}
+                onContentChange={onContentChange}
               />
             </section>
           )}

--- a/app/components/panels/StatisticalModelPanel.tsx
+++ b/app/components/panels/StatisticalModelPanel.tsx
@@ -45,6 +45,11 @@ export default function StatisticalModelPanel({
     (d) => (d.variables?.length ?? 0) > 0,
   );
 
+  const artifactJson = useMemo(
+    () => statisticalModel ? JSON.stringify(statisticalModel) : undefined,
+    [statisticalModel],
+  );
+
   // Build a concise search description from the artifact for evidence search
   const evidenceSearchContent = useMemo(() => {
     if (!statisticalModel) return "";
@@ -158,6 +163,8 @@ export default function StatisticalModelPanel({
                 artifactType="statistical-model"
                 elementId={WHOLE_ARTIFACT_ELEMENT_ID}
                 elementContent={evidenceSearchContent}
+                artifactJson={artifactJson}
+                onContentChange={onContentChange}
               />
             </section>
           )}

--- a/app/components/panels/StatisticalModelPanel.tsx
+++ b/app/components/panels/StatisticalModelPanel.tsx
@@ -44,6 +44,11 @@ export default function StatisticalModelPanel({
     (d) => (d.variables?.length ?? 0) > 0,
   );
 
+  const artifactJson = useMemo(
+    () => statisticalModel ? JSON.stringify(statisticalModel) : undefined,
+    [statisticalModel],
+  );
+
   // Build a concise search description from the artifact for evidence search
   const evidenceSearchContent = useMemo(() => {
     if (!statisticalModel) return "";
@@ -166,6 +171,8 @@ export default function StatisticalModelPanel({
                 artifactType="statistical-model"
                 elementId={WHOLE_ARTIFACT_ELEMENT_ID}
                 elementContent={evidenceSearchContent}
+                artifactJson={artifactJson}
+                onContentChange={onContentChange}
               />
             </section>
           )}

--- a/app/hooks/useEvidenceIntegration.ts
+++ b/app/hooks/useEvidenceIntegration.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { useEvidenceStore } from "@/app/lib/stores/evidenceStore";
+import { fetchApi } from "@/app/lib/formalization/api";
+import {
+  MAX_INTEGRATION_PAPERS,
+  serializeTargetKey,
+  type EvidenceArtifactType,
+  type EvidenceIntegrateResponse,
+  type IntegrationProposal,
+} from "@/app/lib/types/evidence";
+
+/**
+ * Hook for generating and managing evidence-based integration proposals.
+ *
+ * Takes scored papers and the current artifact content, asks the LLM to
+ * propose specific field edits, and manages approve/reject decisions.
+ * The actual application of approved edits is handled by the parent
+ * component via applyProposals + onContentChange.
+ */
+export function useEvidenceIntegration(
+  artifactType: EvidenceArtifactType,
+  elementId: string,
+) {
+  const key = serializeTargetKey({ artifactType, elementId });
+  const { slot, proposals, isIntegrating, error } = useEvidenceStore(
+    useShallow((s) => ({
+      slot: s.slots[key],
+      proposals: s.proposals[key] ?? [],
+      isIntegrating: s.integrating[key] ?? false,
+      error: s.errors[key] ?? null,
+    })),
+  );
+
+  const integrate = useCallback(
+    async (artifactContent: string) => {
+      const { setIntegrating, setProposals, setError } = useEvidenceStore.getState();
+      const currentSlot = useEvidenceStore.getState().slots[key];
+      if (!currentSlot || !currentSlot.scored || currentSlot.papers.length === 0) return;
+      // Guard against concurrent calls
+      if (useEvidenceStore.getState().integrating[key]) return;
+
+      setIntegrating(key, true);
+      setError(key, null);
+      try {
+        // Send top papers by combined score, excluding subsumed papers
+        const overlap = useEvidenceStore.getState().overlap[key];
+        const eligiblePapers = currentSlot.papers.filter((p) => {
+          if (!p.reliability || !p.relatedness) return false;
+          if (overlap?.paperStatus[p.openAlexId] === "subsumed") return false;
+          return true;
+        });
+
+        const sorted = [...eligiblePapers].sort((a, b) => {
+          const scoreA = (a.reliability?.score ?? 0) + (a.relatedness?.score ?? 0);
+          const scoreB = (b.reliability?.score ?? 0) + (b.relatedness?.score ?? 0);
+          return scoreB - scoreA;
+        });
+
+        const topPapers = sorted.slice(0, MAX_INTEGRATION_PAPERS).map((p) => ({
+          openAlexId: p.openAlexId,
+          title: p.title,
+          authors: p.authors,
+          year: p.year,
+          abstract: p.abstract,
+          reliability: p.reliability,
+          relatedness: p.relatedness,
+        }));
+
+        if (topPapers.length === 0) return;
+
+        const result = await fetchApi<EvidenceIntegrateResponse>(
+          "/api/evidence-integrate",
+          {
+            artifactType,
+            artifactContent,
+            papers: topPapers,
+          },
+        );
+
+        // Add client-side IDs and pending decisions
+        const withIds: IntegrationProposal[] = result.proposals.map((p) => ({
+          ...p,
+          id: crypto.randomUUID(),
+          decision: null,
+        }));
+
+        setProposals(key, withIds);
+      } catch (err) {
+        console.error("[useEvidenceIntegration]", err);
+        const message = err instanceof Error ? err.message : "Integration failed";
+        setError(key, message);
+      } finally {
+        useEvidenceStore.getState().setIntegrating(key, false);
+      }
+    },
+    [key, artifactType],
+  );
+
+  const setDecision = useCallback(
+    (proposalId: string, decision: boolean) => {
+      useEvidenceStore.getState().setProposalDecision(key, proposalId, decision);
+    },
+    [key],
+  );
+
+  return {
+    proposals,
+    isIntegrating,
+    error,
+    integrate,
+    setDecision,
+    hasProposals: proposals.length > 0,
+    canIntegrate: (slot?.scored ?? false) && !isIntegrating,
+  };
+}

--- a/app/hooks/useEvidenceIntegration.ts
+++ b/app/hooks/useEvidenceIntegration.ts
@@ -1,7 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
-import { useShallow } from "zustand/react/shallow";
+import { useCallback, useMemo } from "react";
 import { useEvidenceStore } from "@/app/lib/stores/evidenceStore";
 import { fetchApi } from "@/app/lib/formalization/api";
 import {
@@ -11,6 +10,8 @@ import {
   type EvidenceIntegrateResponse,
   type IntegrationProposal,
 } from "@/app/lib/types/evidence";
+
+const EMPTY_PROPOSALS: IntegrationProposal[] = [];
 
 /**
  * Hook for generating and managing evidence-based integration proposals.
@@ -25,14 +26,13 @@ export function useEvidenceIntegration(
   elementId: string,
 ) {
   const key = serializeTargetKey({ artifactType, elementId });
-  const { slot, proposals, isIntegrating, error } = useEvidenceStore(
-    useShallow((s) => ({
-      slot: s.slots[key],
-      proposals: s.proposals[key] ?? [],
-      isIntegrating: s.integrating[key] ?? false,
-      error: s.errors[key] ?? null,
-    })),
-  );
+  // Individual selectors with stable defaults to avoid infinite re-render loops.
+  // useShallow + inline defaults (e.g. ?? []) creates new references every call.
+  const slot = useEvidenceStore((s) => s.slots[key]);
+  const rawProposals = useEvidenceStore((s) => s.proposals[key]);
+  const proposals = rawProposals ?? EMPTY_PROPOSALS;
+  const isIntegrating = useEvidenceStore((s) => s.integrating[key] ?? false);
+  const error = useEvidenceStore((s) => s.errors[key] ?? null);
 
   const integrate = useCallback(
     async (artifactContent: string) => {

--- a/app/hooks/useEvidenceIntegration.ts
+++ b/app/hooks/useEvidenceIntegration.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { useEvidenceStore } from "@/app/lib/stores/evidenceStore";
 import { fetchApi } from "@/app/lib/formalization/api";
 import {

--- a/app/hooks/useEvidenceIntegration.ts
+++ b/app/hooks/useEvidenceIntegration.ts
@@ -106,12 +106,17 @@ export function useEvidenceIntegration(
     [key],
   );
 
+  const clearProposals = useCallback(() => {
+    useEvidenceStore.getState().clearProposals(key);
+  }, [key]);
+
   return {
     proposals,
     isIntegrating,
     error,
     integrate,
     setDecision,
+    clearProposals,
     hasProposals: proposals.length > 0,
     canIntegrate: (slot?.scored ?? false) && !isIntegrating,
   };

--- a/app/lib/stores/evidenceStore.ts
+++ b/app/lib/stores/evidenceStore.ts
@@ -11,7 +11,7 @@
 
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
-import type { EvidenceSlot, PaperScore, OverlapAnalysis } from "@/app/lib/types/evidence";
+import type { EvidenceSlot, PaperScore, OverlapAnalysis, IntegrationProposal } from "@/app/lib/types/evidence";
 
 // ---------------------------------------------------------------------------
 // Debounced localStorage adapter (same pattern as workspaceStore)
@@ -56,12 +56,16 @@ interface EvidenceState {
   slots: Record<string, EvidenceSlot>;
   /** Per-element overlap analysis results */
   overlap: Record<string, OverlapAnalysis>;
+  /** Per-element integration proposals */
+  proposals: Record<string, IntegrationProposal[]>;
   /** Per-element loading state (search or scoring) */
   loading: Record<string, boolean>;
   /** Per-element scoring loading state */
   scoring: Record<string, boolean>;
   /** Per-element overlap analysis loading state */
   analyzing: Record<string, boolean>;
+  /** Per-element integration loading state */
+  integrating: Record<string, boolean>;
   /** Per-element error messages */
   errors: Record<string, string>;
 }
@@ -71,11 +75,18 @@ interface EvidenceActions {
   setLoading: (key: string, loading: boolean) => void;
   setScoring: (key: string, scoring: boolean) => void;
   setAnalyzing: (key: string, analyzing: boolean) => void;
+  setIntegrating: (key: string, integrating: boolean) => void;
   setError: (key: string, error: string | null) => void;
   /** Apply LLM scores to papers in a slot */
   applyScores: (key: string, scores: PaperScore[]) => void;
   /** Apply overlap analysis results */
   applyOverlap: (key: string, analysis: OverlapAnalysis) => void;
+  /** Store integration proposals */
+  setProposals: (key: string, proposals: IntegrationProposal[]) => void;
+  /** Update decision on a single proposal */
+  setProposalDecision: (key: string, proposalId: string, decision: boolean) => void;
+  /** Clear all proposals for a slot */
+  clearProposals: (key: string) => void;
   clearEvidence: (key: string) => void;
   clearAll: () => void;
 }
@@ -83,9 +94,11 @@ interface EvidenceActions {
 const DEFAULT_STATE: EvidenceState = {
   slots: {},
   overlap: {},
+  proposals: {},
   loading: {},
   scoring: {},
   analyzing: {},
+  integrating: {},
   errors: {},
 };
 
@@ -116,6 +129,11 @@ export const useEvidenceStore = create<EvidenceState & EvidenceActions>()(
       setAnalyzing: (key: string, analyzing: boolean) =>
         set((state: EvidenceState) => ({
           analyzing: { ...state.analyzing, [key]: analyzing },
+        })),
+
+      setIntegrating: (key: string, integrating: boolean) =>
+        set((state: EvidenceState) => ({
+          integrating: { ...state.integrating, [key]: integrating },
         })),
 
       setError: (key: string, error: string | null) =>
@@ -162,6 +180,32 @@ export const useEvidenceStore = create<EvidenceState & EvidenceActions>()(
           overlap: { ...state.overlap, [key]: analysis },
         })),
 
+      setProposals: (key: string, proposals: IntegrationProposal[]) =>
+        set((state: EvidenceState) => ({
+          proposals: { ...state.proposals, [key]: proposals },
+        })),
+
+      setProposalDecision: (key: string, proposalId: string, decision: boolean) =>
+        set((state: EvidenceState) => {
+          const current = state.proposals[key];
+          if (!current) return {};
+          return {
+            proposals: {
+              ...state.proposals,
+              [key]: current.map((p) =>
+                p.id === proposalId ? { ...p, decision } : p,
+              ),
+            },
+          };
+        }),
+
+      clearProposals: (key: string) =>
+        set((state: EvidenceState) => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [key]: _removed, ...rest } = state.proposals;
+          return { proposals: rest };
+        }),
+
       clearEvidence: (key: string) =>
         set((state: EvidenceState) => {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -169,32 +213,43 @@ export const useEvidenceStore = create<EvidenceState & EvidenceActions>()(
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { [key]: _o, ...restOverlap } = state.overlap;
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [key]: _p, ...restProposals } = state.proposals;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { [key]: _l, ...restLoading } = state.loading;
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { [key]: _sc, ...restScoring } = state.scoring;
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { [key]: _a, ...restAnalyzing } = state.analyzing;
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [key]: _i, ...restIntegrating } = state.integrating;
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { [key]: _e, ...restErrors } = state.errors;
           return {
             slots: restSlots,
             overlap: restOverlap,
+            proposals: restProposals,
             loading: restLoading,
             scoring: restScoring,
             analyzing: restAnalyzing,
+            integrating: restIntegrating,
             errors: restErrors,
           };
         }),
 
-      clearAll: () => set({ slots: {}, overlap: {}, loading: {}, scoring: {}, analyzing: {}, errors: {} }),
+      clearAll: () => set({
+        slots: {}, overlap: {}, proposals: {},
+        loading: {}, scoring: {}, analyzing: {}, integrating: {}, errors: {},
+      }),
     }),
     {
       name: "evidence-store-v1",
       storage: typeof window !== "undefined"
         ? createJSONStorage(() => debouncedStorage)
         : undefined,
-      // Only persist slots and overlap, not transient loading state
-      partialize: (state: EvidenceState & EvidenceActions) => ({ slots: state.slots, overlap: state.overlap }),
+      // Only persist slots, overlap, and proposals — not transient loading state
+      partialize: (state: EvidenceState & EvidenceActions) => ({
+        slots: state.slots, overlap: state.overlap, proposals: state.proposals,
+      }),
       skipHydration: true,
     },
   ),

--- a/app/lib/types/evidence.ts
+++ b/app/lib/types/evidence.ts
@@ -19,6 +19,9 @@ export type EvidenceTargetKey = {
 /** Element ID used when evidence applies to the whole artifact (not a sub-element) */
 export const WHOLE_ARTIFACT_ELEMENT_ID = "artifact";
 
+/** Max papers to send to the integration API */
+export const MAX_INTEGRATION_PAPERS = 8;
+
 /** Serializes a target key for use as a Record key */
 export function serializeTargetKey(target: EvidenceTargetKey): string {
   return `${target.artifactType}::${target.elementId}`;
@@ -201,4 +204,57 @@ export type EvidenceOverlapRequest = {
 /** API response shape for overlap analysis */
 export type EvidenceOverlapResponse = {
   analysis: OverlapAnalysis;
+};
+
+// ---------------------------------------------------------------------------
+// Integration proposals (Phase 4)
+// ---------------------------------------------------------------------------
+
+/** Edit category for UI grouping and styling */
+export type IntegrationEditType =
+  | "update-prior"        // Evidence suggests updating a numeric value or distribution
+  | "add-evidence"        // Evidence supports an existing claim (strengthen it)
+  | "flag-contradiction"  // Evidence contradicts an existing claim
+  | "refine-wording";     // Evidence suggests more precise language
+
+/** A single proposed edit to an artifact field, based on evidence papers */
+export type IntegrationProposal = {
+  /** Unique ID for this proposal (client-generated) */
+  id: string;
+  /** Dot-notation path to the field, e.g. "hypotheses[1].statement" or "summary" */
+  fieldPath: string;
+  /** Human-readable label, e.g. "Hypothesis H1 statement" */
+  fieldLabel: string;
+  /** The current value of the field (stringified for display) */
+  currentValue: string;
+  /** The proposed replacement value */
+  proposedValue: string;
+  /** 1-2 sentence explanation of why this edit is warranted */
+  rationale: string;
+  /** OpenAlex IDs of papers supporting this proposal */
+  paperIds: string[];
+  /** User decision: null = pending, true = approved, false = rejected */
+  decision: null | boolean;
+  /** Edit category */
+  editType: IntegrationEditType;
+};
+
+/** API request shape for evidence integration */
+export type EvidenceIntegrateRequest = {
+  artifactType: EvidenceArtifactType;
+  /** The full artifact content as JSON string */
+  artifactContent: string;
+  /** Top papers to generate proposals from */
+  papers: Pick<
+    EvidencePaper,
+    "openAlexId" | "title" | "authors" | "year" | "abstract" | "reliability" | "relatedness"
+  >[];
+};
+
+/** Shape returned by the LLM (before client adds id + decision) */
+export type RawIntegrationProposal = Omit<IntegrationProposal, "id" | "decision">;
+
+/** API response shape for evidence integration */
+export type EvidenceIntegrateResponse = {
+  proposals: RawIntegrationProposal[];
 };

--- a/app/lib/utils/applyProposals.test.ts
+++ b/app/lib/utils/applyProposals.test.ts
@@ -51,6 +51,14 @@ describe("resolveFieldPath", () => {
   it("returns null for empty path", () => {
     expect(resolveFieldPath({ a: 1 }, "")).toBeNull();
   });
+
+  it("rejects prototype pollution paths", () => {
+    const obj = { a: 1 };
+    expect(resolveFieldPath(obj, "__proto__")).toBeNull();
+    expect(resolveFieldPath(obj, "constructor")).toBeNull();
+    expect(resolveFieldPath(obj, "prototype")).toBeNull();
+    expect(resolveFieldPath(obj, "__proto__.polluted")).toBeNull();
+  });
 });
 
 describe("getFieldValue", () => {

--- a/app/lib/utils/applyProposals.test.ts
+++ b/app/lib/utils/applyProposals.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import { resolveFieldPath, getFieldValue, applyProposals } from "./applyProposals";
+import type { IntegrationProposal } from "@/app/lib/types/evidence";
+
+function makeProposal(overrides: Partial<IntegrationProposal> = {}): IntegrationProposal {
+  return {
+    id: "p1",
+    fieldPath: "summary",
+    fieldLabel: "Summary",
+    currentValue: "old",
+    proposedValue: "new",
+    rationale: "test",
+    paperIds: ["W1"],
+    decision: true,
+    editType: "refine-wording",
+    ...overrides,
+  };
+}
+
+describe("resolveFieldPath", () => {
+  it("resolves a top-level key", () => {
+    const obj = { summary: "hello" };
+    const result = resolveFieldPath(obj, "summary");
+    expect(result).toEqual({ parent: obj, key: "summary" });
+  });
+
+  it("resolves an array index", () => {
+    const obj = { items: ["a", "b", "c"] };
+    const result = resolveFieldPath(obj, "items[1]");
+    expect(result).toEqual({ parent: obj.items, key: 1 });
+  });
+
+  it("resolves a nested path with array index", () => {
+    const obj = { hypotheses: [{ id: "H1", statement: "foo" }] };
+    const result = resolveFieldPath(obj, "hypotheses[0].statement");
+    expect(result).toEqual({ parent: obj.hypotheses[0], key: "statement" });
+  });
+
+  it("returns null for non-existent top-level key", () => {
+    expect(resolveFieldPath({ a: 1 }, "b")).toBeNull();
+  });
+
+  it("returns null for out-of-bounds array index", () => {
+    expect(resolveFieldPath({ items: [1] }, "items[5]")).toBeNull();
+  });
+
+  it("returns null for path through a primitive", () => {
+    expect(resolveFieldPath({ a: 42 }, "a.b")).toBeNull();
+  });
+
+  it("returns null for empty path", () => {
+    expect(resolveFieldPath({ a: 1 }, "")).toBeNull();
+  });
+});
+
+describe("getFieldValue", () => {
+  it("reads a top-level value", () => {
+    expect(getFieldValue({ summary: "hello" }, "summary")).toBe("hello");
+  });
+
+  it("reads a nested array value", () => {
+    const obj = { hypotheses: [{ statement: "claim" }] };
+    expect(getFieldValue(obj, "hypotheses[0].statement")).toBe("claim");
+  });
+
+  it("returns undefined for missing path", () => {
+    expect(getFieldValue({ a: 1 }, "b")).toBeUndefined();
+  });
+});
+
+describe("applyProposals", () => {
+  it("applies an approved string field edit", () => {
+    const artifact = JSON.stringify({ summary: "old summary", claim: "x" });
+    const result = applyProposals(artifact, [
+      makeProposal({ fieldPath: "summary", proposedValue: "new summary", decision: true }),
+    ]);
+    expect(JSON.parse(result)).toEqual({ summary: "new summary", claim: "x" });
+  });
+
+  it("applies an approved nested field edit", () => {
+    const artifact = JSON.stringify({
+      hypotheses: [{ id: "H1", statement: "old" }],
+    });
+    const result = applyProposals(artifact, [
+      makeProposal({
+        fieldPath: "hypotheses[0].statement",
+        proposedValue: "new statement",
+        decision: true,
+      }),
+    ]);
+    expect(JSON.parse(result).hypotheses[0].statement).toBe("new statement");
+  });
+
+  it("skips rejected proposals", () => {
+    const artifact = JSON.stringify({ summary: "keep me" });
+    const result = applyProposals(artifact, [
+      makeProposal({ fieldPath: "summary", proposedValue: "nope", decision: false }),
+    ]);
+    expect(JSON.parse(result).summary).toBe("keep me");
+  });
+
+  it("skips pending proposals", () => {
+    const artifact = JSON.stringify({ summary: "keep me" });
+    const result = applyProposals(artifact, [
+      makeProposal({ fieldPath: "summary", proposedValue: "nope", decision: null }),
+    ]);
+    expect(JSON.parse(result).summary).toBe("keep me");
+  });
+
+  it("skips proposals with invalid fieldPaths", () => {
+    const artifact = JSON.stringify({ summary: "keep me" });
+    const result = applyProposals(artifact, [
+      makeProposal({ fieldPath: "nonexistent.field", proposedValue: "nope", decision: true }),
+    ]);
+    expect(JSON.parse(result).summary).toBe("keep me");
+  });
+
+  it("applies multiple approved proposals", () => {
+    const artifact = JSON.stringify({
+      summary: "old",
+      assumptions: ["A1", "A2"],
+    });
+    const result = applyProposals(artifact, [
+      makeProposal({ id: "p1", fieldPath: "summary", proposedValue: "new", decision: true }),
+      makeProposal({ id: "p2", fieldPath: "assumptions[0]", proposedValue: "updated A1", decision: true }),
+    ]);
+    const parsed = JSON.parse(result);
+    expect(parsed.summary).toBe("new");
+    expect(parsed.assumptions[0]).toBe("updated A1");
+  });
+
+  it("returns original JSON when no proposals are approved", () => {
+    const artifact = JSON.stringify({ summary: "keep" });
+    const result = applyProposals(artifact, []);
+    expect(result).toBe(artifact);
+  });
+
+  it("parses JSON-valued proposedValue for object fields", () => {
+    const artifact = JSON.stringify({
+      hypotheses: [{ id: "H1", statement: "old", nullHypothesis: "none" }],
+    });
+    // Replace entire hypothesis object
+    const newHypothesis = JSON.stringify({ id: "H1", statement: "new", nullHypothesis: "updated" });
+    const result = applyProposals(artifact, [
+      makeProposal({
+        fieldPath: "hypotheses[0]",
+        proposedValue: newHypothesis,
+        decision: true,
+      }),
+    ]);
+    expect(JSON.parse(result).hypotheses[0]).toEqual({
+      id: "H1",
+      statement: "new",
+      nullHypothesis: "updated",
+    });
+  });
+});

--- a/app/lib/utils/applyProposals.ts
+++ b/app/lib/utils/applyProposals.ts
@@ -6,6 +6,9 @@ import type { IntegrationProposal } from "@/app/lib/types/evidence";
  *
  * Returns null if the path cannot be resolved against the object.
  */
+// Prevent prototype pollution via LLM-generated field paths
+const DENIED_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
+
 export function resolveFieldPath(
   obj: Record<string, unknown>,
   path: string,
@@ -17,6 +20,7 @@ export function resolveFieldPath(
     .filter(Boolean);
 
   if (segments.length === 0) return null;
+  if (segments.some((s) => DENIED_SEGMENTS.has(s))) return null;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- navigating dynamic paths
   let current: any = obj;

--- a/app/lib/utils/applyProposals.ts
+++ b/app/lib/utils/applyProposals.ts
@@ -1,0 +1,88 @@
+import type { IntegrationProposal } from "@/app/lib/types/evidence";
+
+/**
+ * Resolve a dot-notation field path (e.g. "hypotheses[1].statement") to
+ * a { parent, key } pair so the value can be read or written.
+ *
+ * Returns null if the path cannot be resolved against the object.
+ */
+export function resolveFieldPath(
+  obj: Record<string, unknown>,
+  path: string,
+): { parent: Record<string, unknown> | unknown[]; key: string | number } | null {
+  // Split "hypotheses[1].statement" → ["hypotheses", "1", "statement"]
+  const segments = path
+    .replace(/\[(\d+)\]/g, ".$1")
+    .split(".")
+    .filter(Boolean);
+
+  if (segments.length === 0) return null;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- navigating dynamic paths
+  let current: any = obj;
+
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i];
+    const idx = /^\d+$/.test(seg) ? Number(seg) : seg;
+    current = current?.[idx];
+    if (current === undefined || current === null) return null;
+  }
+
+  const lastSeg = segments[segments.length - 1];
+  const lastKey = /^\d+$/.test(lastSeg) ? Number(lastSeg) : lastSeg;
+
+  if (typeof current !== "object" || current === null) return null;
+  if (!(lastKey in current)) return null;
+
+  return { parent: current, key: lastKey };
+}
+
+/**
+ * Read the value at a dot-notation field path.
+ * Returns undefined if the path doesn't resolve.
+ */
+export function getFieldValue(
+  obj: Record<string, unknown>,
+  path: string,
+): unknown {
+  const resolved = resolveFieldPath(obj, path);
+  if (!resolved) return undefined;
+  return (resolved.parent as Record<string | number, unknown>)[resolved.key];
+}
+
+/**
+ * Apply approved integration proposals to an artifact JSON string.
+ *
+ * Only proposals with `decision === true` are applied. Each proposal's
+ * `fieldPath` is resolved against the parsed artifact object and the
+ * field is set to `proposedValue`.
+ *
+ * Returns the updated JSON string, or the original if no proposals apply.
+ */
+export function applyProposals(
+  artifactJson: string,
+  proposals: IntegrationProposal[],
+): string {
+  const approved = proposals.filter((p) => p.decision === true);
+  if (approved.length === 0) return artifactJson;
+
+  const obj = JSON.parse(artifactJson) as Record<string, unknown>;
+
+  for (const proposal of approved) {
+    const resolved = resolveFieldPath(obj, proposal.fieldPath);
+    if (!resolved) continue;
+
+    // Try to parse proposedValue as JSON (for objects/arrays/numbers),
+    // fall back to raw string for plain text fields
+    let value: unknown;
+    try {
+      value = JSON.parse(proposal.proposedValue);
+    } catch {
+      value = proposal.proposedValue;
+    }
+
+    (resolved.parent as Record<string | number, unknown>)[resolved.key] = value;
+  }
+
+  return JSON.stringify(obj);
+}


### PR DESCRIPTION
## Summary

- Adds "Suggest edits" button to evidence panels that asks the LLM to propose specific artifact field changes based on scored papers
- Each proposal shows a visual diff (current vs proposed), rationale, paper citations, and edit-type badge (update-prior, add-evidence, flag-contradiction, refine-wording)
- Users approve or reject each proposal individually, then apply all approved edits in one click via the existing `onContentChange` pipeline

This is Phase 4 of the [evidence grounding architecture](../docs/decisions/001-evidence-grounding-architecture.md), completing the chain of trust: system finds evidence → system judges quality → **system proposes edits** → user approves.

## What changed

**New files (8):**
| File | Purpose |
|------|---------|
| `api/evidence-integrate/route.ts` | POST endpoint — sends artifact + scored papers to Claude Sonnet, returns 2-5 surgical edit proposals |
| `api/evidence-integrate/integrateValidation.ts` | Validates LLM proposals: fieldPath resolves, paperIds valid, currentValue≠proposedValue |
| `api/evidence-integrate/integrateValidation.test.ts` | 11 validation tests |
| `lib/utils/applyProposals.ts` | Pure utility — resolves dot-notation field paths and applies approved proposals to artifact JSON |
| `lib/utils/applyProposals.test.ts` | 18 tests covering path resolution, approval filtering, nested paths, JSON values |
| `hooks/useEvidenceIntegration.ts` | Hook — `integrate`, `setDecision` callbacks; reads proposals/loading from Zustand store |
| `components/features/evidence-search/IntegrationProposalCard.tsx` | Card with diff view, rationale, paper citations, approve/reject buttons |
| `components/features/evidence-search/IntegrationProposalsSection.tsx` | Collapsible container with "Apply N approved edits" button |

**Modified files (5):**
| File | Change |
|------|--------|
| `lib/types/evidence.ts` | `IntegrationProposal`, `EvidenceIntegrateRequest/Response`, `MAX_INTEGRATION_PAPERS` |
| `lib/stores/evidenceStore.ts` | `proposals` + `integrating` state; `setProposals`, `setProposalDecision`, `clearProposals` actions; persists proposals to localStorage |
| `components/features/evidence-search/FindEvidenceButton.tsx` | Orchestrates integration hook; new `artifactJson`/`onContentChange` props |
| `components/panels/StatisticalModelPanel.tsx` | Passes memoized `artifactJson` + `onContentChange` to FindEvidenceButton |
| `components/panels/CounterexamplesPanel.tsx` | Same |

## Test plan

- [ ] `npm test` — 236 tests pass (29 new)
- [ ] `npm run lint` — 0 errors (only pre-existing warnings in page.tsx)
- [ ] `npm run build` — production build succeeds, `/api/evidence-integrate` route listed
- [ ] Manual: dev server → generate statistical model → Find evidence → Score papers → **Suggest edits** → see proposals with diffs → approve some, reject others → **Apply approved edits** → artifact content updates
- [ ] Manual: same flow with counterexamples artifact
- [ ] Verify proposals persist across page refresh (localStorage)
- [ ] Verify "Re-suggest edits" replaces previous proposals

## Areas of uncertainty

- **LLM fieldPath accuracy**: The system prompt includes the exact artifact schema with valid paths, and validation silently drops proposals with invalid paths. May need prompt tuning if the LLM frequently generates bad paths.
- **Stale proposals**: If the user edits the artifact manually after generating proposals, the `currentValue` in proposals may not match anymore. `applyProposals` will still apply them (it uses `fieldPath`, not `currentValue` for targeting). A future improvement could detect staleness and warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)