### PR TITLE
feat: classify counterexamples as hypothetical-empirical or logical

### DIFF
--- a/app/api/evidence-integrate/route.ts
+++ b/app/api/evidence-integrate/route.ts
@@ -46,7 +46,7 @@ Valid fieldPaths include:
   counterexamples: `The artifact is a counterexamples analysis with this structure:
 {
   "claim": "string",
-  "scenarios": [{ "id": "string", "scenario": "string", "targetAssumption": "string", "explanation": "string", "plausibility": "high|medium|low" }],
+  "scenarios": [{ "id": "string", "scenario": "string", "targetAssumption": "string", "explanation": "string", "plausibility": "high|medium|low", "isEmpirical": "boolean (optional)" }],
   "robustnessAssessment": "string",
   "summary": "string"
 }
@@ -56,6 +56,7 @@ Valid fieldPaths include:
 - "scenarios[i].scenario" — a counterexample scenario
 - "scenarios[i].explanation" — why the counterexample works
 - "scenarios[i].plausibility" — plausibility rating (high/medium/low)
+- "scenarios[i].isEmpirical" — whether the counterexample relies on empirical claims
 - "robustnessAssessment" — overall robustness assessment
 - "summary" — the analysis summary`,
 };

--- a/app/api/formalization/counterexamples/route.ts
+++ b/app/api/formalization/counterexamples/route.ts
@@ -12,7 +12,8 @@ Return a JSON object with this exact shape:
       "scenario": "string (concrete description of the counterexample)",
       "targetAssumption": "string (which assumption or condition this challenges)",
       "explanation": "string (why this counterexample is effective — what breaks)",
-      "plausibility": "high | medium | low"
+      "plausibility": "high | medium | low",
+      "isEmpirical": "boolean (true if relies on empirical claims, false if purely logical)"
     }
   ],
   "robustnessAssessment": "string (overall assessment of how robust the claim is given these counterexamples)",
@@ -25,6 +26,9 @@ Important:
 - Include a mix of plausibility levels — some obvious, some subtle
 - Target different assumptions where possible
 - The robustness assessment should be balanced and constructive
+- Set isEmpirical to true when the counterexample relies on empirical claims (data, studies, real-world observations). Set false for purely logical, mathematical, or definitional counterexamples.
+- For empirical counterexamples (isEmpirical: true), use hypothetical framing: describe what kind of evidence *would* contradict the thesis, not that such evidence exists. Example: "If longitudinal data showed X decreases under condition Y, this would undermine the assumption that..."
+- NEVER fabricate specific citations, study names, author names, statistics, or data points
 - Return ONLY the JSON object, no commentary or markdown fences`;
 
 function mockResponse(sourceText: string) {
@@ -38,6 +42,15 @@ function mockResponse(sourceText: string) {
         targetAssumption: "Implicit assumption that the domain is unbounded",
         explanation: "The claim implicitly assumes no boundary effects, but in finite domains this breaks down.",
         plausibility: "medium" as const,
+        isEmpirical: false,
+      },
+      {
+        id: "cx-2",
+        scenario: "If empirical studies showed the effect reverses under high-stress conditions, this would undermine the implicit assumption of context-independence.",
+        targetAssumption: "Implicit assumption that the effect is context-independent",
+        explanation: "The claim does not account for moderating variables. If data demonstrated context-dependence, the universal framing would fail.",
+        plausibility: "high" as const,
+        isEmpirical: true,
       },
     ],
     robustnessAssessment: "Mock assessment: the claim appears moderately robust but has at least one exploitable assumption.",

--- a/app/components/panels/CounterexamplesPanel.test.tsx
+++ b/app/components/panels/CounterexamplesPanel.test.tsx
@@ -15,7 +15,7 @@ vi.mock('./ArtifactPanelShell', () => ({
     hasData ? <div>{children}</div> : <div>empty</div>,
 }))
 
-function makeCx(overrides: Partial<CounterexamplesResponse["counterexamples"]["counterexamples"][0]> = {}) {
+function makeCx(overrides: Partial<CounterexamplesResponse["counterexamples"]["scenarios"][0]> = {}) {
   return {
     id: "cx-1",
     scenario: "A test scenario",
@@ -27,11 +27,11 @@ function makeCx(overrides: Partial<CounterexamplesResponse["counterexamples"]["c
 }
 
 function makeData(
-  cxOverrides: Partial<CounterexamplesResponse["counterexamples"]["counterexamples"][0]> = {},
+  cxOverrides: Partial<CounterexamplesResponse["counterexamples"]["scenarios"][0]> = {},
 ): CounterexamplesResponse["counterexamples"] {
   return {
     claim: "Test claim",
-    counterexamples: [makeCx(cxOverrides)],
+    scenarios: [makeCx(cxOverrides)],
     robustnessAssessment: "Moderate",
     summary: "Test summary",
   };

--- a/app/components/panels/CounterexamplesPanel.test.tsx
+++ b/app/components/panels/CounterexamplesPanel.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import CounterexamplesPanel from './CounterexamplesPanel'
+import type { CounterexamplesResponse } from '@/app/lib/types/artifacts'
+
+// Mock child components to isolate panel logic
+vi.mock('@/app/components/features/output-editing/EditableSection', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+vi.mock('@/app/components/features/evidence-search/FindEvidenceButton', () => ({
+  default: () => <div data-testid="find-evidence" />,
+}))
+vi.mock('./ArtifactPanelShell', () => ({
+  default: ({ children, hasData }: { children: React.ReactNode; hasData: boolean }) =>
+    hasData ? <div>{children}</div> : <div>empty</div>,
+}))
+
+function makeCx(overrides: Partial<CounterexamplesResponse["counterexamples"]["counterexamples"][0]> = {}) {
+  return {
+    id: "cx-1",
+    scenario: "A test scenario",
+    targetAssumption: "Some assumption",
+    explanation: "Why it works",
+    plausibility: "medium" as const,
+    ...overrides,
+  };
+}
+
+function makeData(
+  cxOverrides: Partial<CounterexamplesResponse["counterexamples"]["counterexamples"][0]> = {},
+): CounterexamplesResponse["counterexamples"] {
+  return {
+    claim: "Test claim",
+    counterexamples: [makeCx(cxOverrides)],
+    robustnessAssessment: "Moderate",
+    summary: "Test summary",
+  };
+}
+
+describe('CounterexamplesPanel', () => {
+  const baseProps = {
+    counterexamples: null as CounterexamplesResponse["counterexamples"] | null,
+    loading: false,
+    onContentChange: vi.fn(),
+  };
+
+  it('renders empty state when counterexamples is null', () => {
+    render(<CounterexamplesPanel {...baseProps} />)
+    expect(screen.getByText('empty')).toBeInTheDocument()
+  })
+
+  it('renders counterexample content when data is provided', () => {
+    render(<CounterexamplesPanel {...baseProps} counterexamples={makeData()} />)
+    expect(screen.getByText('Test claim')).toBeInTheDocument()
+    expect(screen.getByText('A test scenario')).toBeInTheDocument()
+  })
+
+  describe('isEmpirical badges', () => {
+    it('shows "Hypothetical" badge when isEmpirical is true', () => {
+      render(<CounterexamplesPanel {...baseProps} counterexamples={makeData({ isEmpirical: true })} />)
+      expect(screen.getByText('Hypothetical')).toBeInTheDocument()
+      expect(screen.queryByText('Logical')).not.toBeInTheDocument()
+    })
+
+    it('shows "Logical" badge when isEmpirical is false', () => {
+      render(<CounterexamplesPanel {...baseProps} counterexamples={makeData({ isEmpirical: false })} />)
+      expect(screen.getByText('Logical')).toBeInTheDocument()
+      expect(screen.queryByText('Hypothetical')).not.toBeInTheDocument()
+    })
+
+    it('shows no badge when isEmpirical is undefined (old artifacts)', () => {
+      render(<CounterexamplesPanel {...baseProps} counterexamples={makeData()} />)
+      expect(screen.queryByText('Hypothetical')).not.toBeInTheDocument()
+      expect(screen.queryByText('Logical')).not.toBeInTheDocument()
+    })
+
+    it('shows guidance text only for empirical counterexamples', () => {
+      const guidance = /Use Find Evidence to search for real papers/
+
+      const { rerender } = render(
+        <CounterexamplesPanel {...baseProps} counterexamples={makeData({ isEmpirical: true })} />,
+      )
+      expect(screen.getByText(guidance)).toBeInTheDocument()
+
+      rerender(<CounterexamplesPanel {...baseProps} counterexamples={makeData({ isEmpirical: false })} />)
+      expect(screen.queryByText(guidance)).not.toBeInTheDocument()
+
+      rerender(<CounterexamplesPanel {...baseProps} counterexamples={makeData()} />)
+      expect(screen.queryByText(guidance)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/app/components/panels/CounterexamplesPanel.tsx
+++ b/app/components/panels/CounterexamplesPanel.tsx
@@ -89,6 +89,16 @@ export default function CounterexamplesPanel({
                       <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${PLAUSIBILITY_STYLES[cx.plausibility] ?? ""}`}>
                         {cx.plausibility}
                       </span>
+                      {cx.isEmpirical === true && (
+                        <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700">
+                          Hypothetical
+                        </span>
+                      )}
+                      {cx.isEmpirical === false && (
+                        <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600">
+                          Logical
+                        </span>
+                      )}
                     </div>
                     <p className="text-sm text-[var(--ink-black)]">{cx.scenario}</p>
                     <div className="text-xs text-[#6B6560]">
@@ -97,6 +107,11 @@ export default function CounterexamplesPanel({
                     <div className="text-xs text-[#6B6560]">
                       <span className="font-semibold">Why it works:</span> {cx.explanation}
                     </div>
+                    {cx.isEmpirical === true && (
+                      <p className="text-xs text-blue-600 italic">
+                        This counterexample describes evidence that would challenge the claim. Use Find Evidence to search for real papers.
+                      </p>
+                    )}
                   </div>
                 </EditableSection>
               ))}

--- a/app/components/panels/CounterexamplesPanel.tsx
+++ b/app/components/panels/CounterexamplesPanel.tsx
@@ -84,6 +84,16 @@ export default function CounterexamplesPanel({
                       <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${PLAUSIBILITY_STYLES[cx.plausibility] ?? ""}`}>
                         {cx.plausibility}
                       </span>
+                      {cx.isEmpirical === true && (
+                        <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700">
+                          Hypothetical
+                        </span>
+                      )}
+                      {cx.isEmpirical === false && (
+                        <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600">
+                          Logical
+                        </span>
+                      )}
                     </div>
                     <p className="text-sm text-[var(--ink-black)]">{cx.scenario}</p>
                     <div className="text-xs text-[#6B6560]">
@@ -92,6 +102,11 @@ export default function CounterexamplesPanel({
                     <div className="text-xs text-[#6B6560]">
                       <span className="font-semibold">Why it works:</span> {cx.explanation}
                     </div>
+                    {cx.isEmpirical === true && (
+                      <p className="text-xs text-blue-600 italic">
+                        This counterexample describes evidence that would challenge the claim. Use Find Evidence to search for real papers.
+                      </p>
+                    )}
                   </div>
                 </EditableSection>
               ))}

--- a/app/components/panels/CounterexamplesPanel.tsx
+++ b/app/components/panels/CounterexamplesPanel.tsx
@@ -9,10 +9,21 @@ import { useFieldUpdaters } from "@/app/hooks/useFieldUpdaters";
 import FindEvidenceButton from "@/app/components/features/evidence-search/FindEvidenceButton";
 import { WHOLE_ARTIFACT_ELEMENT_ID } from "@/app/lib/types/evidence";
 
+const BADGE_BASE = "rounded-full px-2 py-0.5 text-xs font-medium";
+
 const PLAUSIBILITY_STYLES: Record<string, string> = {
   high: "bg-red-100 text-red-700",
   medium: "bg-amber-100 text-amber-700",
   low: "bg-green-100 text-green-700",
+};
+
+// isEmpirical === true → "Hypothetical": empirical counterexamples use hypothetical
+// framing ("if evidence showed X...") to avoid fabricating citations. The label tells
+// the user to verify via Find Evidence rather than trusting the LLM's claim.
+// isEmpirical === undefined (old artifacts) → no badge shown.
+const EMPIRICAL_STYLES: Record<string, { label: string; classes: string }> = {
+  true: { label: "Hypothetical", classes: "bg-blue-100 text-blue-700" },
+  false: { label: "Logical", classes: "bg-gray-100 text-gray-600" },
 };
 
 type CounterexamplesPanelProps = {
@@ -86,17 +97,12 @@ export default function CounterexamplesPanel({
                   <div className="rounded border border-[#DDD9D5] bg-white px-3 py-2 space-y-2">
                     <div className="flex items-center gap-2">
                       <span className="font-mono text-xs text-[#9A9590]">{cx.id}</span>
-                      <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${PLAUSIBILITY_STYLES[cx.plausibility] ?? ""}`}>
+                      <span className={`${BADGE_BASE} ${PLAUSIBILITY_STYLES[cx.plausibility] ?? ""}`}>
                         {cx.plausibility}
                       </span>
-                      {cx.isEmpirical === true && (
-                        <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700">
-                          Hypothetical
-                        </span>
-                      )}
-                      {cx.isEmpirical === false && (
-                        <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600">
-                          Logical
+                      {cx.isEmpirical != null && (
+                        <span className={`${BADGE_BASE} ${EMPIRICAL_STYLES[String(cx.isEmpirical)].classes}`}>
+                          {EMPIRICAL_STYLES[String(cx.isEmpirical)].label}
                         </span>
                       )}
                     </div>

--- a/app/components/panels/CounterexamplesPanel.tsx
+++ b/app/components/panels/CounterexamplesPanel.tsx
@@ -8,10 +8,21 @@ import { useFieldUpdaters } from "@/app/hooks/useFieldUpdaters";
 import FindEvidenceButton from "@/app/components/features/evidence-search/FindEvidenceButton";
 import { WHOLE_ARTIFACT_ELEMENT_ID } from "@/app/lib/types/evidence";
 
+const BADGE_BASE = "rounded-full px-2 py-0.5 text-xs font-medium";
+
 const PLAUSIBILITY_STYLES: Record<string, string> = {
   high: "bg-red-100 text-red-700",
   medium: "bg-amber-100 text-amber-700",
   low: "bg-green-100 text-green-700",
+};
+
+// isEmpirical === true → "Hypothetical": empirical counterexamples use hypothetical
+// framing ("if evidence showed X...") to avoid fabricating citations. The label tells
+// the user to verify via Find Evidence rather than trusting the LLM's claim.
+// isEmpirical === undefined (old artifacts) → no badge shown.
+const EMPIRICAL_STYLES: Record<string, { label: string; classes: string }> = {
+  true: { label: "Hypothetical", classes: "bg-blue-100 text-blue-700" },
+  false: { label: "Logical", classes: "bg-gray-100 text-gray-600" },
 };
 
 type CounterexamplesPanelProps = {
@@ -81,17 +92,12 @@ export default function CounterexamplesPanel({
                   <div className="rounded border border-[#DDD9D5] bg-white px-3 py-2 space-y-2">
                     <div className="flex items-center gap-2">
                       <span className="font-mono text-xs text-[#9A9590]">{cx.id}</span>
-                      <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${PLAUSIBILITY_STYLES[cx.plausibility] ?? ""}`}>
+                      <span className={`${BADGE_BASE} ${PLAUSIBILITY_STYLES[cx.plausibility] ?? ""}`}>
                         {cx.plausibility}
                       </span>
-                      {cx.isEmpirical === true && (
-                        <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700">
-                          Hypothetical
-                        </span>
-                      )}
-                      {cx.isEmpirical === false && (
-                        <span className="rounded-full px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-600">
-                          Logical
+                      {cx.isEmpirical != null && (
+                        <span className={`${BADGE_BASE} ${EMPIRICAL_STYLES[String(cx.isEmpirical)].classes}`}>
+                          {EMPIRICAL_STYLES[String(cx.isEmpirical)].label}
                         </span>
                       )}
                     </div>

--- a/app/lib/types/artifacts.ts
+++ b/app/lib/types/artifacts.ts
@@ -121,6 +121,7 @@ export type CounterexamplesResponse = {
       targetAssumption: string;
       explanation: string;
       plausibility: "high" | "medium" | "low";
+      isEmpirical?: boolean;
     }>;
     robustnessAssessment: string;
     summary: string;


### PR DESCRIPTION
## Summary

- Adds `isEmpirical?: boolean` to the counterexample type so the LLM classifies each counterexample as relying on empirical claims (`true`) or being purely logical (`false`)
- Empirical counterexamples use **hypothetical framing** ("if evidence showed X, this would contradict...") — the LLM never fabricates citations, study names, or data points
- UI shows blue "Hypothetical" badge with guidance to use Find Evidence, or gray "Logical" badge; old artifacts without the field show no badge (backward compatible)
- Updates the evidence-integrate schema so the integration pipeline can reference the new field

## Motivation

Core project principle: trust should never rest on LLM text alone. Counterexamples that make empirical claims were indistinguishable from logical ones, with no signal to the user that verification is needed. This change makes the distinction visible and actionable via the existing evidence grounding pipeline.

## Test plan

- [ ] `npm run lint` — no new errors
- [ ] `npm test -- --run` — all 237 tests pass (on this branch)
- [ ] Generate counterexamples from sample text — verify some are marked `isEmpirical: true` with hypothetical framing
- [ ] Verify blue "Hypothetical" and gray "Logical" badges render correctly
- [ ] Verify guidance text appears only for empirical counterexamples
- [ ] Load an old workspace export — verify counterexamples render without badges (no crash)
- [ ] Use Find Evidence on an empirical counterexample — verify pipeline still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)