### PR TITLE
fix: resolve hydration mismatches on server-persisted state

### DIFF
--- a/app/hooks/useArtifactGeneration.ts
+++ b/app/hooks/useArtifactGeneration.ts
@@ -50,7 +50,10 @@ export function useArtifactGeneration() {
             if (partial && typeof partial === "object") {
               // Extract inner value by response key (e.g. {"causalGraph": {...}} → {...})
               // so the preview matches what panels expect.
-              const inner = (partial as Record<string, unknown>)[responseKey] ?? partial;
+              // Guard: if the extracted value is an array, it's a field-name collision
+              // (e.g. counterexamples.counterexamples) — use the full object instead.
+              const candidate = (partial as Record<string, unknown>)[responseKey];
+              const inner = (candidate != null && !Array.isArray(candidate)) ? candidate : partial;
               setStreamingJsonPreview((prev) => ({ ...prev, [type]: inner }));
             }
           } catch {
@@ -63,7 +66,8 @@ export function useArtifactGeneration() {
         // Parse the final complete JSON
         try {
           const parsed = JSON.parse(stripCodeFences(finalText));
-          return [type, parsed[responseKey] ?? parsed];
+          const candidate = parsed[responseKey];
+          return [type, (candidate != null && !Array.isArray(candidate)) ? candidate : parsed];
         } catch {
           console.error(`[${type}] Failed to parse final JSON`);
           return [type, null];

--- a/app/hooks/useFormalizationSessions.ts
+++ b/app/hooks/useFormalizationSessions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { useCallback, useEffect, useRef, useMemo, useSyncExternalStore } from "react";
 import type { FormalizationSession, SessionScope, SessionsState, ArtifactData, ArtifactType } from "@/app/lib/types/session";
 
 export type SessionRestoreHandler = (session: FormalizationSession) => void;
@@ -8,16 +8,40 @@ export type SessionRestoreHandler = (session: FormalizationSession) => void;
 type SessionUpdatableFields = Partial<Pick<FormalizationSession, "semiformalText" | "leanCode" | "verificationStatus" | "verificationErrors" | "artifacts">>;
 
 const STORAGE_KEY = "metaformalism-sessions";
+const EMPTY_STATE: SessionsState = { sessions: [], activeSessionId: null };
 
 function loadFromStorage(): SessionsState {
-  if (typeof window === "undefined") return { sessions: [], activeSessionId: null };
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) return JSON.parse(raw) as SessionsState;
   } catch {
     // Ignore parse errors
   }
-  return { sessions: [], activeSessionId: null };
+  return EMPTY_STATE;
+}
+
+// External store for SSR-safe hydration (mirrors useWorkspaceSessions pattern).
+// useSyncExternalStore with a server snapshot avoids hydration mismatch (React #418).
+let _fSessionsCache: SessionsState | null = null;
+const _fListeners = new Set<() => void>();
+
+function getFSessionsSnapshot(): SessionsState {
+  if (!_fSessionsCache) _fSessionsCache = loadFromStorage();
+  return _fSessionsCache;
+}
+
+function getFServerSnapshot(): SessionsState {
+  return EMPTY_STATE;
+}
+
+function subscribeToFSessions(cb: () => void): () => void {
+  _fListeners.add(cb);
+  return () => _fListeners.delete(cb);
+}
+
+function emitFSessionsChange(next: SessionsState): void {
+  _fSessionsCache = next;
+  for (const cb of _fListeners) cb();
 }
 
 function scopeMatches(a: SessionScope, b: SessionScope): boolean {
@@ -29,7 +53,14 @@ function scopeMatches(a: SessionScope, b: SessionScope): boolean {
 const DEBOUNCE_MS = 500;
 
 export function useFormalizationSessions(onRestore?: SessionRestoreHandler) {
-  const [state, setState] = useState<SessionsState>(loadFromStorage);
+  // useSyncExternalStore with a server snapshot avoids hydration mismatch
+  // (React error #418): server always renders EMPTY_STATE, client reads localStorage.
+  const state = useSyncExternalStore(subscribeToFSessions, getFSessionsSnapshot, getFServerSnapshot);
+  const setState = useCallback((updater: SessionsState | ((prev: SessionsState) => SessionsState)) => {
+    const next = typeof updater === "function" ? updater(getFSessionsSnapshot()) : updater;
+    emitFSessionsChange(next);
+  }, []);
+
   const mounted = useRef(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const stateRef = useRef(state);
@@ -95,7 +126,7 @@ export function useFormalizationSessions(onRestore?: SessionRestoreHandler) {
     // We compute it eagerly from state to avoid stale closure issues
     newSession.runNumber = runNumber;
     return newSession;
-  }, []);
+  }, [setState]);
 
   const updateSession = useCallback((id: string, updates: SessionUpdatableFields) => {
     setState((prev) => ({
@@ -106,11 +137,11 @@ export function useFormalizationSessions(onRestore?: SessionRestoreHandler) {
           : s
       ),
     }));
-  }, []);
+  }, [setState]);
 
   const selectSession = useCallback((id: string) => {
     setState((prev) => ({ ...prev, activeSessionId: id }));
-  }, []);
+  }, [setState]);
 
   /**
    * Select a session and restore its state into the workspace.
@@ -122,7 +153,7 @@ export function useFormalizationSessions(onRestore?: SessionRestoreHandler) {
     if (!session) return;
     setState((prev) => ({ ...prev, activeSessionId: sessionId }));
     onRestoreRef.current?.(session);
-  }, [state.sessions]);
+  }, [state.sessions, setState]);
 
   /**
    * Mirror an update to the active session (if one exists).
@@ -140,7 +171,7 @@ export function useFormalizationSessions(onRestore?: SessionRestoreHandler) {
         ),
       };
     });
-  }, []);
+  }, [setState]);
 
   /**
    * Upsert an artifact entry in the active session's artifacts[].
@@ -172,7 +203,7 @@ export function useFormalizationSessions(onRestore?: SessionRestoreHandler) {
         }),
       };
     });
-  }, []);
+  }, [setState]);
 
   const sessionsForScope = useCallback((scope: SessionScope): FormalizationSession[] => {
     return state.sessions
@@ -199,7 +230,7 @@ export function useFormalizationSessions(onRestore?: SessionRestoreHandler) {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     setState(data);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-  }, []);
+  }, [setState]);
 
   /** Clear all formalization sessions */
   const clearAllSessions = useCallback(() => {
@@ -207,7 +238,7 @@ export function useFormalizationSessions(onRestore?: SessionRestoreHandler) {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     setState(empty);
     localStorage.setItem(STORAGE_KEY, JSON.stringify(empty));
-  }, []);
+  }, [setState]);
 
   return {
     sessions: state.sessions,

--- a/app/hooks/useWorkspaceSessions.ts
+++ b/app/hooks/useWorkspaceSessions.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { useCallback, useEffect, useRef, useMemo, useSyncExternalStore } from "react";
 import type { PersistedWorkspace, PersistedDecomposition } from "@/app/lib/types/persistence";
 import type { SessionsState } from "@/app/lib/types/session";
 import {
@@ -22,15 +22,41 @@ type WorkspaceSnapshotFns = {
 
 const DEBOUNCE_MS = 500;
 
+const EMPTY_STATE: WorkspaceSessionsState = { sessions: [], activeSessionId: null };
+
 function loadFromStorage(): WorkspaceSessionsState {
-  if (typeof window === "undefined") return { sessions: [], activeSessionId: null };
   try {
     const raw = localStorage.getItem(WORKSPACE_SESSIONS_KEY);
     if (raw) return JSON.parse(raw) as WorkspaceSessionsState;
   } catch {
     // Ignore parse errors
   }
-  return { sessions: [], activeSessionId: null };
+  return EMPTY_STATE;
+}
+
+// Tiny external store for SSR-safe hydration of workspace sessions.
+// useSyncExternalStore with a server snapshot avoids hydration mismatch
+// (React error #418) without needing setState-in-effect.
+let _sessionsCache: WorkspaceSessionsState | null = null;
+const _listeners = new Set<() => void>();
+
+function getSessionsSnapshot(): WorkspaceSessionsState {
+  if (!_sessionsCache) _sessionsCache = loadFromStorage();
+  return _sessionsCache;
+}
+
+function getServerSnapshot(): WorkspaceSessionsState {
+  return EMPTY_STATE;
+}
+
+function subscribeToSessions(cb: () => void): () => void {
+  _listeners.add(cb);
+  return () => _listeners.delete(cb);
+}
+
+function emitSessionsChange(next: WorkspaceSessionsState): void {
+  _sessionsCache = next;
+  for (const cb of _listeners) cb();
 }
 
 function hasWorkspaceContent(ws: PersistedWorkspace): boolean {
@@ -44,7 +70,14 @@ function hasWorkspaceContent(ws: PersistedWorkspace): boolean {
 }
 
 export function useWorkspaceSessions(fns: WorkspaceSnapshotFns) {
-  const [state, setState] = useState<WorkspaceSessionsState>(loadFromStorage);
+  // useSyncExternalStore with a server snapshot avoids hydration mismatch
+  // (React error #418): server always renders EMPTY_STATE, client reads localStorage.
+  const state = useSyncExternalStore(subscribeToSessions, getSessionsSnapshot, getServerSnapshot);
+  const setState = useCallback((updater: WorkspaceSessionsState | ((prev: WorkspaceSessionsState) => WorkspaceSessionsState)) => {
+    const next = typeof updater === "function" ? updater(getSessionsSnapshot()) : updater;
+    emitSessionsChange(next);
+  }, []);
+
   const stateRef = useRef(state);
   useEffect(() => { stateRef.current = state; }, [state]);
 
@@ -102,7 +135,7 @@ export function useWorkspaceSessions(fns: WorkspaceSnapshotFns) {
     };
 
     setState({ sessions: [session], activeSessionId: session.id });
-  }, []);
+  }, [setState]);
 
   /** Snapshot the current workspace into the active workspace session */
   const saveCurrentSession = useCallback(() => {
@@ -128,7 +161,7 @@ export function useWorkspaceSessions(fns: WorkspaceSnapshotFns) {
           : s,
       ),
     }));
-  }, []);
+  }, [setState]);
 
   /** Create a new empty workspace session, auto-saving the current one first */
   const createNewSession = useCallback(() => {
@@ -152,7 +185,7 @@ export function useWorkspaceSessions(fns: WorkspaceSnapshotFns) {
       sessions: [...prev.sessions, newSession],
       activeSessionId: newSession.id,
     }));
-  }, [saveCurrentSession]);
+  }, [saveCurrentSession, setState]);
 
   /** Switch to a different workspace session, auto-saving the current one first */
   const switchToSession = useCallback((targetId: string) => {
@@ -171,7 +204,7 @@ export function useWorkspaceSessions(fns: WorkspaceSnapshotFns) {
     fnsRef.current.resetDecomp(decompData);
 
     setState((prev) => ({ ...prev, activeSessionId: targetId }));
-  }, [saveCurrentSession]);
+  }, [saveCurrentSession, setState]);
 
   const renameSession = useCallback((id: string, title: string) => {
     setState((prev) => ({
@@ -180,7 +213,7 @@ export function useWorkspaceSessions(fns: WorkspaceSnapshotFns) {
         s.id === id ? { ...s, title, updatedAt: new Date().toISOString() } : s,
       ),
     }));
-  }, []);
+  }, [setState]);
 
   const deleteSession = useCallback((id: string) => {
     setState((prev) => {
@@ -205,7 +238,7 @@ export function useWorkspaceSessions(fns: WorkspaceSnapshotFns) {
 
       return { sessions: remaining, activeSessionId: newActiveId };
     });
-  }, []);
+  }, [setState]);
 
   // --- Auto-save: periodically snapshot the active session ---
   // Piggybacks on a 5-second interval rather than every workspace change


### PR DESCRIPTION
## Summary

Cherry-picks two hydration fixes from `integration/4.14` that resolve React error #418 on initial page load. Both fixes replace a `useState(loadFromStorage)` pattern — which runs in the SSR pass with no localStorage access and on the client with real data — with `useSyncExternalStore` + a server snapshot returning empty state.

- **`c2787a9`** (cherry-picked clean from integration/4.14 `5d473ca`): `useWorkspaceSessions` hydration fix, plus a sibling bugfix for a counterexamples crash (ARTIFACT_RESPONSE_KEY `"counterexamples"` collided with the inner array field, causing `parsed["counterexamples"]` to extract the array instead of the wrapper object during streaming).
- **`4028373`** (cherry-picked from integration/4.14 `c3b80c4`, with the OnboardingOverlay portion omitted because that file does not exist on main): `useFormalizationSessions` hydration fix.

## Motivation

Hydration mismatches reproduce on clean `main` during normal workspace-session and formalization-session startup. The fixes already exist on `integration/4.14` but that branch is 180+ commits ahead of main with unrelated feature work, so backporting these narrow fixes standalone unblocks users on main without waiting for the integration merge.

## Test plan

- [x] `npm run lint` — clean (2 pre-existing warnings on `app/page.tsx`, unrelated)
- [x] `npm test` — 185/185 pass
- [x] Manual: hard-refresh the app with a populated workspace session and a formalization session in localStorage → check browser console for React error #418 / hydration mismatch warnings → should be absent
- [x] Manual: generate a counterexamples artifact via streaming → should not crash

## Areas to scrutinize

- `useSyncExternalStore` usage: confirm the subscribe callback only fires when the underlying storage actually changes, not on every render.
- The counterexamples `Array.isArray` guard in `useArtifactGeneration.ts` — is there any path where an intentional array payload for `"counterexamples"` should survive the guard?

## Not included

- `OnboardingOverlay` hydration fix from the original `c3b80c4` — OnboardingOverlay does not exist on main. That fix lands with the onboarding feature itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)