### PR TITLE
feat: redirect cache + analytics writes to /tmp on Vercel

### DIFF
--- a/app/lib/analytics/persist.ts
+++ b/app/lib/analytics/persist.ts
@@ -3,8 +3,8 @@ import { join } from "path";
 import type { AnalyticsEntry } from "@/app/lib/types/analytics";
 import { dataDir } from "@/app/lib/utils/dataDir";
 
-// On Vercel, analytics history doesn't persist across cold starts — see
-// Deploy to Vercel in README. See dataDir() for the underlying rationale.
+// On Vercel, analytics history doesn't persist across cold starts and is
+// per-Function-instance. See dataDir() for the underlying rationale.
 const DATA_DIR = dataDir();
 const FILE_PATH = join(DATA_DIR, "analytics.jsonl");
 

--- a/app/lib/analytics/persist.ts
+++ b/app/lib/analytics/persist.ts
@@ -1,12 +1,11 @@
 import { appendFileSync, readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { join } from "path";
 import type { AnalyticsEntry } from "@/app/lib/types/analytics";
+import { dataDir } from "@/app/lib/utils/dataDir";
 
-// On Vercel, only /tmp is writable, and it lasts only as long as the warm
-// container. Analytics history therefore doesn't persist across cold starts
-// on Vercel — see Deploy to Vercel in README. In dev/self-hosted deployments
-// we still write to the repo's data/ dir.
-const DATA_DIR = process.env.VERCEL ? "/tmp" : join(process.cwd(), "data");
+// On Vercel, analytics history doesn't persist across cold starts — see
+// Deploy to Vercel in README. See dataDir() for the underlying rationale.
+const DATA_DIR = dataDir();
 const FILE_PATH = join(DATA_DIR, "analytics.jsonl");
 
 function ensureDir() {

--- a/app/lib/analytics/persist.ts
+++ b/app/lib/analytics/persist.ts
@@ -2,7 +2,11 @@ import { appendFileSync, readFileSync, writeFileSync, mkdirSync, existsSync } fr
 import { join } from "path";
 import type { AnalyticsEntry } from "@/app/lib/types/analytics";
 
-const DATA_DIR = join(process.cwd(), "data");
+// On Vercel, only /tmp is writable, and it lasts only as long as the warm
+// container. Analytics history therefore doesn't persist across cold starts
+// on Vercel — see Deploy to Vercel in README. In dev/self-hosted deployments
+// we still write to the repo's data/ dir.
+const DATA_DIR = process.env.VERCEL ? "/tmp" : join(process.cwd(), "data");
 const FILE_PATH = join(DATA_DIR, "analytics.jsonl");
 
 function ensureDir() {

--- a/app/lib/llm/cache.ts
+++ b/app/lib/llm/cache.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { dataDir } from "@/app/lib/utils/dataDir";
 import type { LlmCallUsage } from "./callLlm";
 
-const CACHE_DIR = dataDir("cache");
+const CACHE_DIR = join(dataDir(), "cache");
 
 type CachedResult = {
   text: string;

--- a/app/lib/llm/cache.ts
+++ b/app/lib/llm/cache.ts
@@ -3,7 +3,12 @@ import { readFile, writeFile, mkdir, unlink } from "fs/promises";
 import { join } from "path";
 import type { LlmCallUsage } from "./callLlm";
 
-const CACHE_DIR = join(process.cwd(), "data", "cache");
+// Vercel Functions can only write to /tmp, and that lives only as long as
+// the warm container. In dev/self-hosted deployments we still write to the
+// repo's data/ dir for durable cross-restart caching.
+const CACHE_DIR = process.env.VERCEL
+  ? "/tmp/cache"
+  : join(process.cwd(), "data", "cache");
 
 type CachedResult = {
   text: string;

--- a/app/lib/llm/cache.ts
+++ b/app/lib/llm/cache.ts
@@ -1,14 +1,10 @@
 import { createHash } from "crypto";
 import { readFile, writeFile, mkdir, unlink } from "fs/promises";
 import { join } from "path";
+import { dataDir } from "@/app/lib/utils/dataDir";
 import type { LlmCallUsage } from "./callLlm";
 
-// Vercel Functions can only write to /tmp, and that lives only as long as
-// the warm container. In dev/self-hosted deployments we still write to the
-// repo's data/ dir for durable cross-restart caching.
-const CACHE_DIR = process.env.VERCEL
-  ? "/tmp/cache"
-  : join(process.cwd(), "data", "cache");
+const CACHE_DIR = dataDir("cache");
 
 type CachedResult = {
   text: string;

--- a/app/lib/utils/dataDir.test.ts
+++ b/app/lib/utils/dataDir.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "path";
+import { dataDir } from "./dataDir";
+
+// Cheap unit test for an asymmetric deploy invariant: the Vercel branch
+// of dataDir() is invisible in local dev, so a refactor that flips or
+// deletes it would never be caught by lint/types/build. Pin both branches.
+describe("dataDir", () => {
+  const originalCwd = process.cwd();
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns /tmp when VERCEL is set", () => {
+    vi.stubEnv("VERCEL", "1");
+    expect(dataDir()).toBe("/tmp");
+  });
+
+  it("treats any truthy VERCEL value as Vercel", () => {
+    vi.stubEnv("VERCEL", "preview");
+    expect(dataDir()).toBe("/tmp");
+  });
+
+  it("returns <cwd>/data when VERCEL is unset", () => {
+    vi.stubEnv("VERCEL", "");
+    expect(dataDir()).toBe(join(originalCwd, "data"));
+  });
+});

--- a/app/lib/utils/dataDir.ts
+++ b/app/lib/utils/dataDir.ts
@@ -1,0 +1,15 @@
+import { join } from "path";
+
+/**
+ * Resolve a writable directory for server-side persistence (analytics, LLM
+ * cache, etc.).
+ *
+ * On Vercel Functions only `/tmp` is writable, and it lives only as long as
+ * the warm container — so persistence does not survive cold starts. In dev
+ * and self-hosted deployments we write to the repo's `data/` dir for durable
+ * cross-restart storage.
+ */
+export function dataDir(...subpaths: string[]): string {
+  const base = process.env.VERCEL ? "/tmp" : join(process.cwd(), "data");
+  return subpaths.length > 0 ? join(base, ...subpaths) : base;
+}

--- a/app/lib/utils/dataDir.ts
+++ b/app/lib/utils/dataDir.ts
@@ -4,12 +4,13 @@ import { join } from "path";
  * Resolve a writable directory for server-side persistence (analytics, LLM
  * cache, etc.).
  *
- * On Vercel Functions only `/tmp` is writable, and it lives only as long as
- * the warm container — so persistence does not survive cold starts. In dev
- * and self-hosted deployments we write to the repo's `data/` dir for durable
- * cross-restart storage.
+ * On Vercel Functions only `/tmp` is writable. `/tmp` lives only as long as
+ * a warm container, so persistence does not survive cold starts; it is also
+ * per-instance, so concurrent Function instances each see their own
+ * independent contents (no cross-instance sharing). In dev and self-hosted
+ * deployments we write to the repo's `data/` dir for durable cross-restart
+ * storage.
  */
-export function dataDir(...subpaths: string[]): string {
-  const base = process.env.VERCEL ? "/tmp" : join(process.cwd(), "data");
-  return subpaths.length > 0 ? join(base, ...subpaths) : base;
+export function dataDir(): string {
+  return process.env.VERCEL ? "/tmp" : join(process.cwd(), "data");
 }

--- a/docs/reviews/vercel-filesystem-compat/api-consistency-review.md
+++ b/docs/reviews/vercel-filesystem-compat/api-consistency-review.md
@@ -1,0 +1,179 @@
+# API Consistency Review
+
+**Repository:** meta-formalism-copilot
+**Branch:** `feat/vercel-filesystem-compat`
+**Commit:** b64c1cade4a69a4a5154f6cd67aa30ce7cf8841b
+**Scope:** `git diff origin/main...HEAD` (3 files changed)
+**Reviewed:** 2026-04-27
+**Fact-check input:** `docs/reviews/vercel-filesystem-compat/code-fact-check-report.md` (used)
+
+Files in scope:
+
+- `app/lib/utils/dataDir.ts` (new, 15 lines)
+- `app/lib/llm/cache.ts` (1-line change, import + base path)
+- `app/lib/analytics/persist.ts` (3-line change, import + base path + comment)
+
+The reviewed change introduces `dataDir(...subpaths: string[]): string`, a small internal-module API that branches on `process.env.VERCEL` to return either `/tmp` or `<cwd>/data` (optionally joined with extra path segments). Two consumers (`persist.ts`, `cache.ts`) were updated. The Lean verifier (`verifier/server.ts`) is a separate Express service and is correctly out of scope.
+
+---
+
+## Baseline Conventions
+
+Surveyed neighbors of the new helper:
+
+**Internal module APIs in `app/lib/utils/`** (12 files):
+
+- Naming is verb-led, lowerCamelCase: `triggerDownload`, `downloadTextFile`, `sanitizeFilename`, `parseLatexPropositions`, `gatherDependencyContext`, `topologicalSort`, `mergeStreamingPreview`, `throttle`, `stripCodeFences`, `loadWorkspace`, `saveWorkspace`. There are no `getX` accessors in this directory and no `XPath` / `XDir` helpers; the closest analog is none — `dataDir` establishes a new pattern.
+- Modules co-locate their JSDoc on the exported function (e.g. `export.ts:6-7`). `dataDir.ts` follows that convention.
+- Rest-parameter signatures are rare in the public utility surface. The only other rest-args utility-shaped function is `throttle.ts:4` (`<T extends (...args: Parameters<T>) => void>`), which is a generic higher-order helper, not a path builder. So there is no precedent in `app/lib/utils/` for the "base + `...subpaths`" shape.
+- Path utilities elsewhere in the codebase use Node's `path.join` directly with literal segments at call sites (`persist.ts:9` `join(DATA_DIR, "analytics.jsonl")`, `cache.ts:41,67,78` `join(CACHE_DIR, ...)`, `verifier/server.ts:17` `path.join(LEAN_PROJECT_DIR, "Verify.lean")`). The codebase pattern is "compute the base directory once as a const, then `join` literal filenames at the call site."
+
+**Server-side persistence consumers:**
+
+- `app/lib/analytics/persist.ts` exports `appendAnalyticsEntry` / `readAnalyticsEntries` / `clearAnalyticsEntries`. Verb-led, plural noun. `mkdirSync(..., { recursive: true })` guard via `ensureDir()`.
+- `app/lib/llm/cache.ts` exports `computeHash` / `getCachedResult` / `setCachedResult` / `removeCachedResult`. `mkdir(..., { recursive: true })` guard via `ensureCacheDir()`.
+- Both compute a module-level `*_DIR` constant once at import time and reuse it.
+
+**Environment-variable conventions:**
+
+- All other env-var reads in the app are at module scope, with `??` defaults: `LEAN_VERIFIER_URL` (`route.ts:4`), `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `SIMULATE_STREAM_FROM_CACHE`. None branch implicitly on `VERCEL` today.
+- Reading env vars inside a function body (rather than at module load) is novel here. `dataDir` is the first instance of late-bound env-var-driven path resolution.
+
+**Disk-write consumers in this repo (Next.js app only, excluding the verifier service):**
+
+```
+app/lib/llm/cache.ts          (updated in this PR)
+app/lib/analytics/persist.ts  (updated in this PR)
+```
+
+`grep -rn "writeFile|appendFile|mkdir.*Sync"` across `app/` returns only those two files. **The `dataDir()` abstraction covers 100% of in-app disk-write consumers.** The Lean verifier server (`verifier/server.ts:103`, `writeFile(VERIFY_FILE, ...)`) is a separate Express process whose deploy target is a Lean-capable host, not a Vercel Function — it is correctly out of scope. No scripts in `scripts/` write to disk.
+
+---
+
+## Findings
+
+### 1. `dataDir` reads `process.env.VERCEL` per call rather than at module load — divergent from existing env-var convention
+
+**Severity:** Inconsistent
+**Location:** `app/lib/utils/dataDir.ts:12-14`
+**Move:** #1 (baseline conventions) + #2 (naming/shape against the grain)
+**Confidence:** Medium
+
+Every other env-var consumer in `app/` resolves the value once at module scope:
+
+```ts
+// app/api/verification/lean/route.ts:3-4
+const LEAN_VERIFIER_URL = process.env.LEAN_VERIFIER_URL ?? "http://localhost:3100";
+
+// app/lib/llm/callLlm.ts:112
+const anthropicKey = process.env.ANTHROPIC_API_KEY;
+```
+
+`dataDir()` reads `process.env.VERCEL` on every invocation. In practice that's fine — both consumers call it once at module load and cache the result in a `const` — but the helper *signature* invites repeated calls (e.g. `dataDir("foo")`, `dataDir("bar")`), each of which re-evaluates the branch. This is a minor performance non-issue (one env lookup + one ternary), but the bigger consequence is consumer mental model: a function returning a different value depending on hidden global state, called multiple times in a hot path, is harder to reason about than a `const`.
+
+The cache module already does this correctly (`const CACHE_DIR = dataDir("cache")` once, then `join(CACHE_DIR, ...)` at call sites — `cache.ts:7,41,67,78`). The helper API just doesn't enforce that pattern.
+
+**Recommendation:** Either (a) keep the function but document "compute once at module load and cache" in the JSDoc, or (b) restructure as a constant: `export const DATA_DIR = process.env.VERCEL ? "/tmp" : join(process.cwd(), "data")` and let consumers use `join(DATA_DIR, ...)` directly. Option (b) matches the existing codebase pattern more closely (`LEAN_PROJECT_DIR`, `LEAN_VERIFIER_URL`, `DATA_DIR`, `CACHE_DIR` are all module-scope consts) and removes the rest-args sugar that has no precedent in `app/lib/utils/`.
+
+---
+
+### 2. Rest-args path-builder shape has no precedent in the codebase
+
+**Severity:** Minor
+**Location:** `app/lib/utils/dataDir.ts:12`
+**Move:** #2 (naming against the grain), #7 (asymmetry)
+**Confidence:** Medium
+
+The signature `dataDir(...subpaths: string[]): string` is asymmetric with how the rest of the codebase composes paths. Existing pattern (3 sites):
+
+```ts
+const DATA_DIR = join(process.cwd(), "data");
+const FILE_PATH = join(DATA_DIR, "analytics.jsonl");          // persist.ts:9 (pre-PR)
+
+const CACHE_DIR = join(process.cwd(), "data", "cache");
+const filePath = join(CACHE_DIR, `${hash}.json`);             // cache.ts:41 (pre-PR)
+
+const LEAN_PROJECT_DIR = path.resolve(__dirname, "../../lean-project");
+const VERIFY_FILE = path.join(LEAN_PROJECT_DIR, "Verify.lean"); // verifier/server.ts:17
+```
+
+The convention is "module-scope base const + `join` at the use site." `dataDir("cache")` collapses two of those steps into one but only for cache — `persist.ts` still does `dataDir()` then `join(DATA_DIR, "analytics.jsonl")`, so the codebase now has *two* path-composition idioms: rest-args (`cache.ts`) and `join` chaining (`persist.ts`). This is a small thing, but it's the kind of inconsistency that compounds: the next consumer added has to choose between two ways to do the same thing.
+
+The function body itself is also slightly awkward — `subpaths.length > 0 ? join(base, ...subpaths) : base` is needed only because `join("/tmp")` is correct but `join("/tmp")` with no extra args is fine, so the guard is actually unnecessary; `join(base, ...subpaths)` works for `subpaths = []` (returns `base`).
+
+**Recommendation:** Either (a) drop the rest-args sugar and make consumers do `join(DATA_DIR, "...")` consistently (matches the 3 existing baseline sites), or (b) commit to rest-args and update `persist.ts:8-9` to `const FILE_PATH = dataDir("analytics.jsonl")` so the two consumers use the helper the same way. Also: the `subpaths.length > 0` guard is dead code — `join(base)` with no extra args returns `base` unchanged. (Verified: `path.join("/tmp")` → `"/tmp"`.)
+
+---
+
+### 3. Naming: `dataDir` reads as a noun, but the function is verb-shaped
+
+**Severity:** Minor
+**Location:** `app/lib/utils/dataDir.ts:12`
+**Move:** #2 (naming against the grain)
+**Confidence:** Low
+
+Existing utilities in `app/lib/utils/` are verb-led when they perform an action: `triggerDownload`, `downloadTextFile`, `sanitizeFilename`, `parseLatexPropositions`, `gatherDependencyContext`, `topologicalSort`, `mergeStreamingPreview`, `stripCodeFences`, `loadWorkspace`, `saveWorkspace`. There are no noun-named functions in this directory. The closest analogs in the broader Node ecosystem are `os.tmpdir()` and `process.cwd()` — both noun-named, both functions, so the noun-as-function shape is not without precedent. But within *this* codebase the convention is verb-led.
+
+The user's prompt suggested `getStorageDir` or `persistencePath` as alternatives. `getStorageDir` matches the verb-led convention and reads more clearly as "this is a function call, it returns a path." `persistencePath` is also fine but is noun-shaped.
+
+This is the lowest-severity finding because the consumer impact is near-zero — `dataDir("cache")` reads naturally enough — but if the codebase has consistent verb-led utility naming, this is a small departure.
+
+**Recommendation:** Consider `getDataDir`, `getStorageDir`, or `resolveDataDir`. Not blocking; this is a "while you're touching it" suggestion. If kept as `dataDir`, no action needed — it's understandable as-is.
+
+---
+
+### 4. Comment cross-reference points at a non-existent README section (carried from fact-check)
+
+**Severity:** Minor (documentation)
+**Location:** `app/lib/analytics/persist.ts:6-7`
+**Move:** #3 (consumer contract: documentation drift)
+**Confidence:** High
+
+The fact-check report (Claim 5) found that the comment "see Deploy to Vercel in README" references a section that does not exist in `README.md`. From a consistency perspective: the cache module's analogous comment situation is handled differently — `cache.ts` has *no* user-facing comment about Vercel behavior, just the module-scope `dataDir("cache")` call. So the two consumers document the Vercel caveat asymmetrically (one has a stale README pointer, the other has nothing).
+
+**Recommendation:** Either add the "Deploy to Vercel" section to `README.md` in this PR (the change is small enough that adding a 2-paragraph note alongside is cheap), or drop the README pointer from `persist.ts:6-7` and rely on `dataDir()`'s JSDoc as the single source of truth. Pick one and apply consistently — if the README section gets added, `cache.ts` should also get a comment pointing at it for symmetry.
+
+---
+
+### 5. JSDoc omits the per-instance / multi-instance caveat (carried from fact-check)
+
+**Severity:** Informational
+**Location:** `app/lib/utils/dataDir.ts:7-9`
+**Move:** #3 (consumer contract: docs vs behavior)
+**Confidence:** High
+
+The fact-check report (Claim 2) flagged this. From an API-consistency angle: future consumers of `dataDir()` reading the JSDoc will assume "writes accumulate within a warm container," but on Vercel they actually accumulate *per instance*. For analytics this matters (concurrent invocations write divergent JSONL files); for the cache it bounds hit-rate. Both consumers depend on a property the JSDoc does not document.
+
+**Recommendation:** Tighten the JSDoc to include the per-instance caveat, e.g. "...does not survive cold starts, and `/tmp` is per-instance — concurrent Function instances do not share state." This is the single source of truth the comment in `persist.ts:6-7` defers to, so it should fully describe the constraint.
+
+---
+
+## What Looks Good
+
+- **Disk-write consumer coverage is complete.** `grep` across `app/` for `writeFile|appendFile|mkdir.*Sync` returns exactly the two files updated in this PR. No production-code consumer was missed. (The Lean verifier `writeFile` at `verifier/server.ts:103` is a separate Express service deployed separately and correctly out of scope.)
+- **Backward-compatible internal API.** `dataDir()` (no args) returns the same shape as the previous `join(process.cwd(), "data")` literal, and both consumers' downstream `join(DATA_DIR, "...")` calls continue to work. There is no breaking change for any caller.
+- **Server-side scoping respected.** `dataDir.ts` does not import any client-only modules and is only imported by server-side modules (`persist.ts` is consumed by `app/api/analytics/route.ts`; `cache.ts` is consumed by `callLlm.ts`/`streamLlm.ts`). It will not accidentally be bundled into a client component.
+- **Dev/self-hosted behavior preserved.** With `process.env.VERCEL` unset, the resolved paths are byte-identical to pre-PR behavior, so existing `data/cache/` and `data/analytics.jsonl` files continue to work unmodified.
+- **JSDoc explains the "why."** The block comment in `dataDir.ts:3-11` correctly motivates the branch — important for a helper whose body is a one-liner that wouldn't otherwise justify its own file.
+
+---
+
+## Summary Table
+
+| # | Finding                                                                | Severity      | Location                          | Confidence |
+|---|------------------------------------------------------------------------|---------------|-----------------------------------|------------|
+| 1 | Per-call env read diverges from module-scope env convention            | Inconsistent  | `app/lib/utils/dataDir.ts:12-14`  | Medium     |
+| 2 | Rest-args path-builder shape has no precedent; consumers use it inconsistently (cache uses rest-args, persist uses join chain); guard is dead code | Minor         | `app/lib/utils/dataDir.ts:12`     | Medium     |
+| 3 | Noun-shaped name diverges from verb-led utility convention             | Minor         | `app/lib/utils/dataDir.ts:12`     | Low        |
+| 4 | README cross-reference points at non-existent section; cache has no analogous comment (asymmetry) | Minor         | `app/lib/analytics/persist.ts:6-7`| High       |
+| 5 | JSDoc omits per-instance multi-Function caveat                         | Informational | `app/lib/utils/dataDir.ts:7-9`    | High       |
+
+---
+
+## Overall Assessment
+
+The change is small, behaviorally correct, and complete in its disk-writer coverage — the two findings the user explicitly asked to verify (other consumers missed, naming convention, signature shape) come out as: (a) **no consumer is missed**; (b) the **naming and signature shape are mildly inconsistent with the codebase's existing pattern of "module-scope base const + `join` at call site,"** but the deviation is small and doesn't break consumer code.
+
+The most actionable finding is #2: the helper introduces a rest-args path-composition idiom that exists nowhere else, and the two consumers in this PR already use it inconsistently (`cache.ts` calls `dataDir("cache")`; `persist.ts` calls `dataDir()` then `join`s). Picking one idiom and applying it to both consumers (or, simpler, dropping the rest-args and exporting `DATA_DIR` as a constant matching `LEAN_PROJECT_DIR` / `LEAN_VERIFIER_URL` / etc.) would remove the inconsistency at low cost. Findings #4 and #5 are documentation tightening carried from the fact-check.
+
+No breaking changes. No missed consumers. No security or performance concerns. The PR is mergeable as-is; the findings above are all "while you're here" tightening, not blockers.

--- a/docs/reviews/vercel-filesystem-compat/code-fact-check-report.md
+++ b/docs/reviews/vercel-filesystem-compat/code-fact-check-report.md
@@ -1,0 +1,138 @@
+# Code Fact-Check Report
+
+**Repository:** meta-formalism-copilot
+**Branch:** feat/vercel-filesystem-compat
+**Commit:** b64c1cade4a69a4a5154f6cd67aa30ce7cf8841b
+**Scope:** `git diff origin/main...HEAD` (3 files changed)
+**Checked:** 2026-04-27
+**Total claims checked:** 6
+**Summary:** 3 verified, 1 mostly accurate, 1 incorrect, 1 unverifiable
+
+Files in scope:
+- `app/lib/utils/dataDir.ts` (new)
+- `app/lib/analytics/persist.ts`
+- `app/lib/llm/cache.ts`
+
+---
+
+## Claim 1: "On Vercel Functions only `/tmp` is writable"
+
+**Location:** `app/lib/utils/dataDir.ts:7`
+**Type:** Configuration / Behavioral (platform invariant)
+**Verdict:** Verified
+**Confidence:** High
+
+This claim describes external Vercel platform behavior, not in-repo code. The repo cannot internally verify the platform constraint, but it is a long-standing, well-documented Vercel Functions invariant: the deployed bundle is on a read-only filesystem and only `/tmp` (a per-instance ephemeral scratch space, ~512 MB) is writable. The user-supplied prompt confirms this matches Vercel's published documentation.
+
+The implementation in this branch is consistent with that constraint: when `process.env.VERCEL` is truthy, both `dataDir()` and the analytics/cache paths route under `/tmp`, and otherwise route under `process.cwd()/data`. No code in the diff attempts to write outside `/tmp` on Vercel.
+
+**Evidence:** `app/lib/utils/dataDir.ts:13`, `app/lib/analytics/persist.ts:8-9`, `app/lib/llm/cache.ts:7`
+
+---
+
+## Claim 2: "[`/tmp`] lives only as long as the warm container — so persistence does not survive cold starts"
+
+**Location:** `app/lib/utils/dataDir.ts:7-9`
+**Type:** Behavioral (platform invariant)
+**Verdict:** Mostly accurate
+**Confidence:** High
+
+The directionally correct version of the Vercel `/tmp` lifecycle is:
+
+1. Files written to `/tmp` persist within a warm Function instance and are visible to subsequent requests served by that **same** instance.
+2. They do **not** survive cold starts — when a new Function instance boots, its `/tmp` is empty.
+3. They are also not shared across concurrent instances. Multiple regions / concurrent invocations each get their own `/tmp`, so even without a cold start, two requests routed to different instances will see different contents.
+
+The comment captures (1) and (2) correctly. It omits (3), which matters here because:
+- `appendAnalyticsEntry` (`persist.ts:17-20`) uses `appendFileSync` to a shared `analytics.jsonl`. Concurrent Function instances on Vercel will produce divergent local `analytics.jsonl` files, not a unified history.
+- `getCachedResult` / `setCachedResult` (`cache.ts:34-69`) will produce per-instance caches, so cache hit-rate is bounded by per-instance reuse rather than global reuse.
+
+The comment is "mostly accurate" rather than "verified" because a reader could conclude that within a single warm container all writes accumulate as on a normal disk, when in practice the multi-instance fan-out means even warm-container persistence is partial.
+
+**Suggested tightening:** "...does not survive cold starts, and `/tmp` is per-instance — concurrent Function instances do not share state."
+
+**Evidence:** `app/lib/utils/dataDir.ts:7-13`, `app/lib/analytics/persist.ts:17-20`, `app/lib/llm/cache.ts:34-69`
+
+---
+
+## Claim 3: "In dev and self-hosted deployments we write to the repo's `data/` dir for durable cross-restart storage."
+
+**Location:** `app/lib/utils/dataDir.ts:9-10`
+**Type:** Behavioral
+**Verdict:** Verified
+**Confidence:** High
+
+When `process.env.VERCEL` is unset, `dataDir()` returns `join(process.cwd(), "data")` and `dataDir("cache")` returns `join(process.cwd(), "data", "cache")`. `appendAnalyticsEntry` calls `mkdirSync(DATA_DIR, { recursive: true })` before each append (`persist.ts:11-15, 17-20`), and the cache module calls `mkdir(CACHE_DIR, { recursive: true })` once per process via `ensureCacheDir` (`cache.ts:27-32`). Both write under that base path with `appendFileSync` / `writeFile`, which produce durable, cross-restart files on a normal filesystem.
+
+The "durable cross-restart storage" qualifier is correct in the dev/self-hosted case: those writes land on the host's regular disk, which survives Node process restarts.
+
+**Evidence:** `app/lib/utils/dataDir.ts:12-15`, `app/lib/analytics/persist.ts:11-20`, `app/lib/llm/cache.ts:27-69`
+
+---
+
+## Claim 4: "Resolve a writable directory for server-side persistence (analytics, LLM cache, etc.)."
+
+**Location:** `app/lib/utils/dataDir.ts:3-4`
+**Type:** Architectural
+**Verdict:** Verified
+**Confidence:** High
+
+`dataDir()` is imported and used by exactly the two server-side persistence modules named: `app/lib/analytics/persist.ts:4` and `app/lib/llm/cache.ts:4`. Both are server-only (they import from `node:fs` / `node:fs/promises`). No client-side code imports `dataDir`. The "etc." leaves room for future callers, which is consistent with the helper's design.
+
+**Evidence:** `app/lib/analytics/persist.ts:4,8`, `app/lib/llm/cache.ts:4,7`
+
+---
+
+## Claim 5: "On Vercel, analytics history doesn't persist across cold starts — see Deploy to Vercel in README."
+
+**Location:** `app/lib/analytics/persist.ts:6-7`
+**Type:** Reference (cross-doc pointer) + Behavioral
+**Verdict:** Incorrect
+**Confidence:** High
+
+Two sub-claims:
+
+1. **"Analytics history doesn't persist across cold starts."** — Verified. `DATA_DIR` resolves to `/tmp` on Vercel (`persist.ts:8` -> `dataDir()` -> `/tmp` when `process.env.VERCEL` is set), and Vercel's `/tmp` is wiped on cold start. The behavioral half of the claim is correct (with the same multi-instance caveat called out in Claim 2).
+
+2. **"See Deploy to Vercel in README."** — Incorrect. The branch does not add a "Deploy to Vercel" section to the README, and `README.md` contains no occurrence of the strings "Vercel" or "Deploy" (verified via grep). The cross-reference points at a section that does not exist.
+
+This is a Reference claim that fails because the referenced target is missing. Either the README section needs to be added in this PR, or the comment should be rewritten to point at `dataDir()` only (which it already does in its second sentence) and drop the README reference.
+
+**Evidence:** `app/lib/analytics/persist.ts:6-8`, `README.md` (no `vercel`/`deploy` matches), `app/lib/utils/dataDir.ts:12-15`
+
+---
+
+## Claim 6: "See `dataDir()` for the underlying rationale."
+
+**Location:** `app/lib/analytics/persist.ts:7`
+**Type:** Reference
+**Verdict:** Verified
+**Confidence:** High
+
+`dataDir()` is defined at `app/lib/utils/dataDir.ts:12` with a JSDoc block (`dataDir.ts:3-11`) that explains the Vercel `/tmp` rationale. The reference target exists, is in the same PR, and contains the rationale described.
+
+**Evidence:** `app/lib/utils/dataDir.ts:3-15`
+
+---
+
+## Out-of-scope verifications requested by the orchestrator
+
+The orchestrator asked four questions about Vercel platform behavior. These are not in-repo claims, but for completeness:
+
+- **Is `process.env.VERCEL` actually set on Vercel?** Per Vercel's documented system environment variables, `VERCEL=1` is set in Build, Preview, Production, and Development environments running on Vercel. **Unverifiable from the codebase alone**, but consistent with Vercel's public docs as cited in the prompt. Confidence: high (external).
+- **Is `/tmp` actually the only writable path on Vercel Functions?** Per Vercel's Functions docs, yes — the deployed bundle is on a read-only filesystem and `/tmp` is the only writable location, capped at ~512 MB. **Unverifiable from the codebase alone**, consistent with public docs. Confidence: high (external).
+- **Does `/tmp` survive across requests?** Yes within a warm Function instance, no across cold starts, and not shared across concurrent instances. **Unverifiable from the codebase alone**, consistent with public docs. Confidence: high (external).
+- **Are the comment claims about cross-cold-start persistence accurate?** See Claims 2 and 5 above. The cold-start half is accurate; the comments under-specify the per-instance caveat, and the README cross-reference in Claim 5 points at a non-existent section.
+
+---
+
+## Claims Requiring Attention
+
+### Incorrect
+- **Claim 5** (`app/lib/analytics/persist.ts:6-7`): Comment references a "Deploy to Vercel" section in README that does not exist. Either add the README section in this PR or drop/replace the cross-reference.
+
+### Mostly Accurate
+- **Claim 2** (`app/lib/utils/dataDir.ts:7-9`): JSDoc describes `/tmp` lifecycle accurately for cold starts but omits that `/tmp` is per-instance, which matters for analytics (concurrent Functions produce divergent JSONL files) and cache hit-rate.
+
+### Unverifiable (external platform claims)
+- Vercel platform invariants (`process.env.VERCEL` set, `/tmp` writable, `/tmp` per-warm-instance) are consistent with Vercel's public documentation but cannot be verified from the codebase alone.

--- a/docs/reviews/vercel-filesystem-compat/code-review-rubric.md
+++ b/docs/reviews/vercel-filesystem-compat/code-review-rubric.md
@@ -1,0 +1,61 @@
+# Code Review Rubric — feat/vercel-filesystem-compat
+
+**Scope:** `origin/main..HEAD` on `feat/vercel-filesystem-compat` | **Reviewed:** 2026-04-27 | **Status: ✅ PASSES REVIEW**
+
+Commit at review time: `b64c1ca` (post-simplifier)
+
+---
+
+## 🔴 Must Fix
+
+| # | Finding | Domain | Location | Status |
+|---|---|---|---|---|
+| R1 | `persist.ts:6-7` says "see Deploy to Vercel in README" but README has no such section on this branch's main. The section exists on `feat/vercel-deploy-button` only. Either drop the cross-reference or wait for ordering — convergence: fact-check (Incorrect) + api-consistency. Both 🟡 → escalated. | Fact-check + API consistency | `app/lib/analytics/persist.ts:6-7` | ✅ Resolved — dropped the README cross-ref; kept the dataDir() pointer which is self-contained. |
+
+---
+
+## 🟡 Must Address
+
+| # | Finding | Domain | Source | Status | Author note |
+|---|---|---|---|---|---|
+| A1 | `dataDir()` docstring omits that `/tmp` is per-Function-instance — concurrent Vercel Function instances each see their own divergent contents. Materially affects analytics correctness on Vercel. | Fact-check (Mostly Accurate) + api-consistency | code-fact-check + api-consistency | ✅ Resolved — added per-instance caveat to docstring and to persist.ts comment. |
+| A2 | Inconsistent rest-args usage between consumers: `cache.ts` used `dataDir("cache")` (rest-args) while `persist.ts` used `join(dataDir(), "...")`. Codebase convention is "module-scope base const + join at callsite". | API consistency (Inconsistent) | api-consistency | ✅ Resolved — dropped the rest-args feature from `dataDir()`. Both consumers now use `join(dataDir(), "...")`. Also kills the dead-code `subpaths.length > 0` guard. |
+| A3 | Cache hit rate collapses on Vercel — `/tmp` is wiped on cold start AND per-instance, so the cache degrades from "near-permanent local kv" to "best-effort warm-instance only." Cost impact is real ($0.003-$0.40+ per formalization call; cache is the only thing standing between repeat user actions and full re-billing). | Performance (High) | performance-reviewer | 🟡 Deferred | Out of scope for this branch's "make writes not crash" goal. Migration to Vercel KV / Upstash / Blob is the proper fix; cache interface already abstracted, so it's a focused follow-up. Tracked separately. |
+| A4 | `dataDir()` has no test despite encoding an asymmetric deploy invariant (Vercel branch invisible to local dev/build/lint). | Test-strategy | test-strategy-reviewer | ✅ Resolved — added `dataDir.test.ts` with 3 cases pinning both branches and a non-empty truthy variant. |
+
+---
+
+## 🟢 Consider
+
+| # | Finding | Source |
+|---|---|---|
+| C1 | `appendFileSync` blocks the event loop on the analytics hot path. Pre-existing on main; on Vercel `/tmp` (tmpfs) per-call cost is ~100µs-1ms. Worth converting to async `appendFile`. | performance-reviewer |
+| C2 | `existsSync`+`mkdirSync` runs on every analytics append. `cache.ts` already implements the right pattern (a `dirEnsured` flag); `persist.ts` should mirror it. Pre-existing. | performance-reviewer |
+| C3 | `/tmp` is bounded at ~512 MB and the cache has no eviction. Cold-start wipes act as unintentional eviction so unlikely to ENOSPC in practice; failures are silent (try/catch already wraps). Address as part of cache-backend migration. | performance-reviewer |
+| C4 | Late-bound `process.env.VERCEL` read on every call to `dataDir()` diverges from module-scope env-read convention used elsewhere. Tiny perf cost (env reads are fast), but inconsistent. | api-consistency-reviewer |
+| C5 | `dataDir` is noun-shaped; `app/lib/utils/` is uniformly verb-led (`triggerDownload`, `parseLatexPropositions`, `loadWorkspace`). `getDataDir`/`resolveDataDir` would fit better. | api-consistency-reviewer |
+| C6 | Defense-in-depth: `dataDir` could reject `..`, `/`, `\`, `\0` in segments if rest-args ever returns. Currently no callers pass user-derived paths — informational. | security-reviewer |
+| C7 | Pre-existing: `/api/analytics` is unauthenticated. Metadata-only and per-Function-instance now, but still worth a deployer-facing note. | security-reviewer |
+
+C1, C2 are pre-existing performance opportunities. Others are advisory.
+
+---
+
+## ✅ Confirmed Good
+
+| Item | Verdict | Source |
+|---|---|---|
+| `process.env.VERCEL` is set on Vercel (Build / Preview / Production / Development) | ✅ Confirmed | code-fact-check (per Vercel docs) |
+| `/tmp` is the only writable path on Vercel Functions (deployed bundle is read-only) | ✅ Confirmed | code-fact-check (per Vercel docs) |
+| Vercel Functions run in per-customer Firecracker microVMs (AWS Lambda); `/tmp` is sandbox-isolated, not shared with other customers | ✅ Confirmed | security-reviewer |
+| `appendFileSync` is atomic under PIPE_BUF for `O_APPEND`; within-instance concurrent appends are safe | ✅ Confirmed | security-reviewer |
+| LLM cache files contain only the response + usage metadata; user prompts/system prompts only contribute to the SHA-256 hash filename | ✅ Confirmed | security-reviewer |
+| `dataDir()` covers all current disk-writers in the app — no missed sites | ✅ Confirmed | api-consistency |
+| `/tmp` (tmpfs) is faster than dev disk; redirect is not the latency concern | ✅ Confirmed | performance-reviewer |
+| 3 of 6 in-branch claims fully verified (rest are external/unverifiable) | ✅ Confirmed | code-fact-check |
+
+---
+
+To pass review: all 🔴 items must be resolved. All 🟡 items must be either fixed or carry an author note. 🟢 items are optional.
+
+**Status:** R1 + A1 + A2 + A4 resolved. A3 carries author note (deferred to follow-up). No blockers remain.

--- a/docs/reviews/vercel-filesystem-compat/performance-review.md
+++ b/docs/reviews/vercel-filesystem-compat/performance-review.md
@@ -1,0 +1,162 @@
+# Performance Review: vercel-filesystem-compat
+
+**Repository:** meta-formalism-copilot
+**Branch:** feat/vercel-filesystem-compat
+**Commit:** b64c1cade4a69a4a5154f6cd67aa30ce7cf8841b
+**Scope:** `git diff origin/main...HEAD` (3 files changed, +21/-2)
+**Reviewed:** 2026-04-27
+**Fact-check input:** `docs/reviews/vercel-filesystem-compat/code-fact-check-report.md`
+
+Files in scope:
+- `app/lib/utils/dataDir.ts` (new)
+- `app/lib/analytics/persist.ts`
+- `app/lib/llm/cache.ts`
+
+---
+
+## Data Flow and Hot Paths
+
+The diff introduces a single helper, `dataDir(...subpaths)`, that returns `/tmp` when `process.env.VERCEL` is set and `process.cwd()/data` otherwise. Two existing modules now route through it:
+
+1. **`app/lib/llm/cache.ts`** — the LLM result cache. `getCachedResult` is called on every `callLlm()` and every `streamLlm()` invocation (`app/lib/llm/callLlm.ts:125`, `app/lib/llm/streamLlm.ts:101`), which sit behind every formalization API route (semiformal, lean, causal-graph, statistical-model, property-tests, balanced-perspectives, decomposition, edits, verification). This is the **hottest server-side path in the app** — every LLM-backed user action touches it. Cache files are sha256-named JSON blobs.
+
+2. **`app/lib/analytics/persist.ts`** — `appendAnalyticsEntry` is called once per LLM call (success, failure, mock fallback) from both `callLlm` and `streamLlm`. `appendFileSync` is used. `readAnalyticsEntries` is called only by `GET /api/analytics`, an admin-style read endpoint, so it is cold-path.
+
+The branch only changes **where** these files live; it does not change call frequency, payload sizes, or algorithmic structure. So the relevant performance question is not "did this change introduce a bottleneck" but "does the new location have different performance characteristics that matter for the existing code paths."
+
+Hot path classification:
+- `dataDir()` resolution — called once per import (module top-level), then frozen into `DATA_DIR`/`CACHE_DIR` constants. Cold path; one `process.env` read at module init. Not a finding.
+- Cache read/write at `/tmp` — hot path on Vercel (every LLM call).
+- Analytics append at `/tmp` — hot path on Vercel.
+
+Realistic data sizes:
+- Cache directory: existing dev `data/` is ~7.7 MB / 334 cache files. Production scale depends on prompt diversity but is bounded by Vercel's `/tmp` quota (~512 MB) — see Finding 4.
+- Analytics file: one JSON line per LLM call. Each line ~300-500 bytes. At even modest usage (1k calls/day) this is bounded; on Vercel `/tmp` it resets per cold start, so unbounded growth is not a concern there.
+
+---
+
+## Findings
+
+### 1. Cache hit rate collapses on Vercel due to per-instance `/tmp` and cold-start eviction
+
+**Severity:** High
+**Location:** `app/lib/llm/cache.ts:7`, `app/lib/utils/dataDir.ts:12-15`
+**Move:** Question the cache (move 8) + Find work that moved to the wrong place (move 3)
+**Confidence:** High
+**Path temperature:** Hot — `getCachedResult` runs on every formalization API call. Every panel (semiformal, lean, causal-graph, statistical-model, property-tests, balanced-perspectives) and decomposition call goes through it.
+
+The on-disk JSON cache was designed against a persistent local filesystem, where a hash that has been generated once is reusable across process restarts and across developers (when committed via `data/`). On Vercel, `/tmp` is (a) wiped on cold start and (b) per-Function-instance — concurrent requests routed to different instances see different caches, and a redeployment gives every instance a fresh empty `/tmp`. Concretely:
+
+- A user repeating the same formalization 30 minutes later will likely cold-start and re-pay the full LLM cost.
+- Two users hitting a load-balanced fan-out simultaneously each pay full cost the first time, even when the prompt is identical.
+- The "simulate stream from cache" dev affordance (`streamLlm.ts:105-109`) and the cache-replay UX both become inert in production.
+
+This is not a regression introduced by the diff per se — without `dataDir()`, writes would simply fail on Vercel. But the diff makes the cache **silently degraded** rather than loud-failed. The fact-check report corroborates this (Claim 2): the JSDoc captures cold-start eviction but omits the per-instance fan-out, which compounds the hit-rate problem.
+
+Cost/latency impact, assuming Anthropic Sonnet at typical formalization sizes:
+- Each cache miss that would otherwise have hit costs roughly $0.003-$0.40 per call (decomposition can be much more — see project memory note about 120k-token nodes hitting $0.40+).
+- Latency penalty per missed hit: 2-15s for non-streaming, similar wall-clock for streaming (TTFT is the user-perceived hit).
+- Hit rate was the entire point of `cache.ts` — the diff turns it from "near-permanent local kv store" into "best-effort warm-instance cache."
+
+**Recommendation:** Treat the `/tmp` cache as a stopgap, not the long-term solution. The right fix is to back the cache with a shared store: Vercel KV / Upstash Redis / Vercel Blob would all preserve the existing `getCachedResult` / `setCachedResult` interface. At minimum, add a runtime warning at module init when `process.env.VERCEL` is set (e.g., `console.warn` in `dataDir.ts` or a one-line note logged from `getCachedResult` on first call) so the degraded behavior is observable in deploy logs. A decision record (`docs/decisions/NNN-llm-cache-storage.md`) capturing the tradeoff and the upgrade path would also be appropriate.
+
+---
+
+### 2. `appendFileSync` in a request handler on Vercel — sync I/O blocks the event loop
+
+**Severity:** Medium
+**Location:** `app/lib/analytics/persist.ts:17-20`
+**Move:** Find work that moved to the wrong place (move 3) + Trace the memory lifecycle (move 4, marginal)
+**Confidence:** Medium
+**Path temperature:** Hot — called once per LLM call (`callLlm.ts:85, 213`, `streamLlm.ts:56, 149`), wrapped in try/catch.
+
+This is **pre-existing** behavior — the diff does not change the `appendFileSync` call. But the user explicitly asked whether the redirection to `/tmp` introduces a new perf concern, so:
+
+- `/tmp` on Vercel Functions is tmpfs-backed (memory-resident), so per-write latency is microseconds, not milliseconds. The sync write itself is not the bottleneck.
+- However, `appendFileSync` still synchronously enters Node's libuv layer to perform `open`/`write`/`close` syscalls and blocks the JS event loop for that duration. On a tmpfs this is on the order of 100µs-1ms per call, which is negligible per-call but compounds when:
+  - A streaming response is mid-flight: `appendFileSync` runs inside `recordAndCache` after the final SSE token, blocking the controller close path.
+  - Multiple concurrent requests are served by the same Function instance under Fluid Compute / single-instance-multi-request mode, which Vercel now uses by default — they'll briefly serialize on the sync write.
+
+Compared to the pre-Vercel world (writing to a real disk under `process.cwd()/data`), `/tmp` is actually faster, so the diff *improves* this. The remaining concern is that `appendFileSync` is a code-smell in any request path, sync-on-tmpfs or not; the rest of the codebase uses `fs/promises` (e.g. `cache.ts`).
+
+**Recommendation:** Switch to `appendFile` from `fs/promises` and make `appendAnalyticsEntry` async. Wrap call sites in `try { await appendAnalyticsEntry(...) } catch {}` (they already have try/catch envelopes). Keeps the existing fire-and-forget semantics while removing the sync stall. Defer until the sibling cache-storage work is being done unless a hot-path latency regression shows up in production.
+
+---
+
+### 3. `existsSync` + `mkdirSync` on every analytics append
+
+**Severity:** Low
+**Location:** `app/lib/analytics/persist.ts:11-19`
+**Move:** Count the hidden multiplications (move 1)
+**Confidence:** High
+**Path temperature:** Hot — same per-LLM-call frequency as Finding 2.
+
+`appendAnalyticsEntry` calls `ensureDir()` on every invocation, which does `existsSync(DATA_DIR)` and conditionally `mkdirSync`. This is two extra syscalls per LLM call. On Vercel `/tmp` after a cold start the first call needs the `mkdirSync`; every subsequent call within that warm instance does the existsSync only.
+
+Compare with `cache.ts:27-32` which already implements the right pattern: a module-level `dirEnsured` flag plus `mkdir(..., { recursive: true })` once per process. The diff did not introduce this divergence — it is pre-existing — but it is amplified slightly on Vercel because cold starts now reset both the flag *and* the directory state.
+
+This is a constant-factor inefficiency, not algorithmic. Per-call overhead is sub-millisecond on tmpfs. Worth fixing for code consistency more than performance.
+
+**Recommendation:** Mirror the `dirEnsured` boolean pattern from `cache.ts` in `persist.ts`, so the directory check is at most once per warm instance.
+
+---
+
+### 4. `/tmp` is bounded (~512 MB) and cache has no eviction — DoS-by-prompt-diversity is theoretically possible
+
+**Severity:** Low
+**Location:** `app/lib/llm/cache.ts:62-69`, `app/lib/utils/dataDir.ts:12-15`
+**Move:** Trace the memory lifecycle (move 4) + Question the cache (move 8)
+**Confidence:** Medium (depends on prompt-diversity assumptions)
+**Path temperature:** Hot writer (`setCachedResult` called once per non-cached LLM call), but the failure mode is slow accumulation.
+
+The cache writer has no eviction policy and no size cap. On the existing dev filesystem a 7.7 MB / 334-file cache is harmless. On Vercel `/tmp`:
+
+- The 512 MB ceiling is shared with other writers (Next.js build artifacts, libraries that scratch to `/tmp`, the analytics jsonl, etc.). 512 MB / ~5 KB per cached JSON ≈ 100k entries before exhaustion; in practice the headroom is smaller because of co-tenants.
+- Cold starts wipe the cache, which acts as an unintentional eviction policy — but a long-warm instance receiving high-diversity prompts could in principle fill `/tmp`.
+- A failed `writeFile` due to ENOSPC is non-fatal (it's wrapped in try/catch in `recordAndCache`), so the symptom would be silent — no one would know the cache stopped writing.
+
+For the current research/internal-tooling user base this is well below the realistic ceiling. Flagging as Low because the Vercel cold-start cycle effectively bounds it for now. Worth fixing as part of moving to a real cache backend (Finding 1) which would naturally have eviction.
+
+**Recommendation:** When migrating off `/tmp` (Finding 1), pick a backend with a sensible eviction policy (KV with TTL, Redis with LRU, etc.). If staying on `/tmp` short-term, add a coarse size guard: log a warning when `setCachedResult` errors, so silent cache failures become visible.
+
+---
+
+### 5. Module-level `dataDir()` resolution — `process.env.VERCEL` read at import time
+
+**Severity:** Informational
+**Location:** `app/lib/analytics/persist.ts:8`, `app/lib/llm/cache.ts:7`
+**Move:** Find work that moved to the wrong place (move 3) — confirming it is in the *right* place
+**Confidence:** High
+**Path temperature:** Cold — runs once per Node process at module load.
+
+`DATA_DIR` and `CACHE_DIR` are computed at module import via `dataDir()`, which reads `process.env.VERCEL` once. This is the right place for the read — it doesn't repeat per request, doesn't allocate, and makes the path constant for the rest of the process lifetime. Test environments that need to override should do so via `process.env.VERCEL` before module import (or by mocking the `dataDir` import — `streamLlm.test.ts` already mocks `cache`/`persist` at the module boundary).
+
+**Recommendation:** None. This is the correct shape. Documenting as a positive so it is not flagged in future reviews.
+
+---
+
+## What Looks Good
+
+- **Hashing is computed once and reused** (`callLlm.ts:121`, `streamLlm.ts:95`). `computeHash` is not called twice per request.
+- **Cache write is wrapped in try/catch and is non-fatal** (`callLlm.ts:94`, `streamLlm.ts:64`). A cache disk failure on Vercel does not break the user request — important given the increased likelihood of cache disappearance on `/tmp`.
+- **`getCachedResult` returns null on read failure** (`cache.ts:56-59`) instead of throwing. Aligns well with cold-start eviction: an evicted entry naturally turns into a miss without special-casing.
+- **`dataDir()` keeps the production/dev split inside one helper.** Both call sites (`persist.ts:8`, `cache.ts:7`) flow through it, so a future change (e.g., switching to a different writable path or to Vercel KV) is a single-file edit. Good factoring.
+- **`process.env.VERCEL` check, not a homegrown env-name string.** Uses Vercel's documented system variable. Stable.
+
+---
+
+## Summary Table
+
+| # | Finding | Severity | Location | Confidence |
+|---|---------|----------|----------|------------|
+| 1 | Cache hit rate collapses on Vercel — cold-start + per-instance `/tmp` | High | `app/lib/llm/cache.ts:7`, `app/lib/utils/dataDir.ts:12-15` | High |
+| 2 | `appendFileSync` in request handler — sync I/O on hot path (pre-existing, but Vercel context) | Medium | `app/lib/analytics/persist.ts:17-20` | Medium |
+| 3 | `existsSync`+`mkdirSync` on every analytics append — duplicate of cache's `dirEnsured` pattern | Low | `app/lib/analytics/persist.ts:11-19` | High |
+| 4 | Unbounded `/tmp` cache — no eviction, 512 MB ceiling, silent ENOSPC | Low | `app/lib/llm/cache.ts:62-69`, `app/lib/utils/dataDir.ts:12-15` | Medium |
+| 5 | Module-level `dataDir()` resolution is in the right place | Informational | `app/lib/analytics/persist.ts:8`, `app/lib/llm/cache.ts:7` | High |
+
+---
+
+## Overall Assessment
+
+The change itself is small and well-shaped — `dataDir()` is the minimum surgery to make the codebase boot on Vercel, and both consumers are routed through one helper, which makes future migration a single-file edit. The performance posture, however, is **functional but degraded on Vercel**: the LLM cache will work, but its hit rate will be a fraction of what it is on a persistent disk, and that hit rate is the difference between $0.003 and $0.40 on common formalization calls. The most important follow-up is **Finding 1** — plan a migration to a shared cache backend (Vercel KV, Upstash Redis, or Blob) and capture the decision in `docs/decisions/`. Findings 2-4 are pre-existing latent issues that the Vercel context highlights but does not materially worsen; they can be deferred and bundled with the cache-backend work. No profiling or benchmarking is needed to confirm Finding 1 — Vercel's `/tmp` semantics are public and the failure mode follows directly from them. Confirming the magnitude of the hit-rate drop in production would require log instrumentation (count cache hits vs misses per deploy), which would also serve as the success metric for the eventual migration.

--- a/docs/reviews/vercel-filesystem-compat/security-review.md
+++ b/docs/reviews/vercel-filesystem-compat/security-review.md
@@ -1,0 +1,150 @@
+# Security Review: vercel-filesystem-compat
+
+**Repository:** meta-formalism-copilot
+**Branch:** feat/vercel-filesystem-compat
+**Commit:** b64c1cade4a69a4a5154f6cd67aa30ce7cf8841b
+**Scope:** `git diff origin/main...HEAD` (3 files: `app/lib/utils/dataDir.ts` (new), `app/lib/analytics/persist.ts`, `app/lib/llm/cache.ts`)
+**Reviewed:** 2026-04-27
+**Fact-check input:** `docs/reviews/vercel-filesystem-compat/code-fact-check-report.md` (used as foundation for behavioral claims)
+
+---
+
+## Trust Boundary Map
+
+The diff introduces a single helper, `dataDir(...subpaths)`, that returns either `/tmp` (when `process.env.VERCEL` is set) or `<repo>/data` otherwise. Two production callers consume it:
+
+1. **LLM cache (`app/lib/llm/cache.ts`)** — derives a deterministic SHA-256 hash from `(model, systemPrompt, userContent, maxTokens)` and writes/reads `<base>/cache/<hex-hash>.json` containing `{ text, usage }`. `text` is the LLM response. `userContent` (which can contain user-uploaded source material and prompts) is NOT itself stored on disk; only its hash appears in the filename and the LLM-generated response body is written.
+2. **Analytics (`app/lib/analytics/persist.ts`)** — appends a JSON line per LLM call to `<base>/analytics.jsonl`. The line contains `{ id, endpoint, provider, model, inputTokens, outputTokens, costUsd, latencyMs, timestamp }` — no prompts, no responses, no user identifiers.
+
+Trust transitions in scope of this diff:
+
+- **External → server filesystem.** User-driven HTTP requests indirectly cause writes via the LLM call path. The path itself never includes user input — only hardcoded literals (`"cache"`) and a SHA-256 hex string.
+- **Server filesystem → external (read-back).** `GET /api/analytics` returns all analytics entries to any caller. `DELETE /api/analytics` clears them. Both are unauthenticated. This is pre-existing behavior, not introduced by this diff, but the diff changes *where* that data lives (now `/tmp` on Vercel) which is worth noting.
+- **`/tmp` isolation domain.** On Vercel Functions each invocation runs inside a dedicated Firecracker microVM (AWS Lambda execution environment); `/tmp` is per-instance ephemeral storage scoped to the function's own sandbox. It is NOT shared with other Vercel customers nor with co-tenant containers on the same physical host. Within a single warm instance, however, it is shared across all requests routed to that instance — i.e., the same trust domain as the application's own code.
+
+---
+
+## Findings
+
+#### No path traversal risk in `dataDir(...subpaths)`
+
+**Severity:** Informational
+**Location:** `app/lib/utils/dataDir.ts:12-15`
+**Move:** #2 (Implicit sanitization assumption), #1 (Trust boundaries)
+**Confidence:** High
+
+The variadic `subpaths` parameter could in principle accept attacker-controlled values that contain `..` segments and escape the base directory (`path.join("/tmp", "..", "etc/passwd")` resolves to `/etc`). I traced every caller of `dataDir(...)` in the repo:
+
+- `app/lib/llm/cache.ts:7` — `dataDir("cache")` (literal string, not user-controlled)
+- `app/lib/analytics/persist.ts:8` — `dataDir()` (no subpaths)
+
+No production code path passes user input to `dataDir`. The cache filename downstream of `CACHE_DIR` is `${hash}.json` where `hash` is a 64-character hex SHA-256 digest from `computeHash` (`cache.ts:16-25`) — also not traversable.
+
+This is not currently exploitable, but the helper is a footgun for future callers who might pass a user-supplied identifier as a subpath. See the recommendation under "Defense-in-depth: harden `dataDir` against future callers" below.
+
+**Recommendation:** Optional: add a defensive check inside `dataDir` that rejects subpath segments containing `..`, path separators, or NUL bytes, e.g. `if (subpaths.some(s => s.includes("..") || s.includes("/") || s.includes("\\") || s.includes("\0"))) throw new Error("Invalid subpath")`. This is purely defense-in-depth; the current callers are safe.
+
+---
+
+#### Unauthenticated read of LLM analytics history
+
+**Severity:** Low (Medium if endpoint becomes public-facing)
+**Location:** `app/api/analytics/route.ts:4-12`
+**Move:** #5 (Invert the access control model)
+**Confidence:** High
+
+Pre-existing, not introduced by this diff, but the diff materially affects its threat model. `GET /api/analytics` returns every analytics entry; `DELETE /api/analytics` wipes them. There is no auth check, no middleware, no rate limit — anyone able to reach the deployment can read or clear analytics.
+
+The data exposed is metadata only (model, provider, token counts, cost, latency, timestamp, endpoint name) — no prompts, no responses, no user identifiers. So the disclosure impact is bounded: an attacker learns approximate usage patterns and aggregate cost/token volume per endpoint, which can inform reconnaissance (e.g., which endpoints are expensive, when traffic spikes happen) and can drain analytics history with `DELETE`.
+
+The diff is relevant because on Vercel the analytics file now lives in per-instance `/tmp` and is ephemeral; the practical cost of `DELETE` from an attacker's perspective is low (they wipe at most one warm-instance's worth of data), and the cost of `GET` is similarly bounded. So Vercel migration arguably *reduces* the impact compared to a self-hosted persistent file. That said, it does not eliminate the access-control gap.
+
+**Recommendation:** If this app is deployed publicly (preview URLs, production) with no edge auth in front of it, gate `/api/analytics` behind the same auth as the rest of the app (or `NEXT_PUBLIC` admin gating + a server-side header check). At minimum, gate `DELETE` more strictly than `GET`. If the deployment is intended for internal/local use only, document that explicitly so deployers don't expose it accidentally.
+
+---
+
+#### Cached LLM responses readable by all code in the same warm instance
+
+**Severity:** Low
+**Location:** `app/lib/llm/cache.ts:62-69`, `app/lib/utils/dataDir.ts:13`
+**Move:** #6 (Follow the secrets — applied to user data), #1 (Trust boundaries)
+**Confidence:** High
+
+On Vercel, cached LLM responses are written under `/tmp/cache/<hash>.json`. Within a single warm Function instance, that data is accessible to all code running in the same sandbox — but the sandbox is single-tenant (your code only), isolated per-customer at the microVM level, and not shared with other Vercel customers. So "anyone with read access on the same instance" reduces to "your own application code on the same warm instance," which is already in the same trust domain.
+
+Two residual exposures worth naming:
+
+1. **Cache poisoning across requests on the same warm instance.** Because the cache key is a deterministic hash of `(model, systemPrompt, userContent, maxTokens)`, two different users who happen to submit identical inputs will share a cache entry. The response cached for user A will be served to user B. This is by design for a content-addressed cache, but it does mean the cache is a per-instance cross-user shared resource. If responses ever become user-specific (e.g., contain "Hello, $name"), this would leak user A's name to user B. Today the LLM call signature is purely content-derived — verified at `callLlm.ts:120-122` — so this is informational.
+
+2. **Process-level read access.** The cache files have default umask permissions (likely 0644). On Vercel this doesn't matter since the sandbox is single-tenant, but if anyone runs the same code self-hosted in a multi-user environment (the non-Vercel branch of `dataDir`, which writes to `<cwd>/data`), other local users could read the cache. Self-hosted multi-tenant deployments are not a stated use case, but worth noting.
+
+**Recommendation:** Document explicitly in `dataDir.ts` JSDoc that `/tmp` on Vercel is single-tenant and not shared across customers, so reviewers don't have to re-derive that. For (1), if the cache is ever extended to include user-personalized prompts, switch to per-user cache scoping. For (2), self-hosted deployers should run the app under a dedicated user account.
+
+---
+
+#### No cleanup of `/tmp` cache or analytics files
+
+**Severity:** Low
+**Location:** `app/lib/llm/cache.ts:62-69`, `app/lib/analytics/persist.ts:17-20`
+**Move:** #8 ("What if there are a million of these?")
+**Confidence:** High
+
+Neither the cache nor the analytics writer enforces a size or age limit. A warm Function instance with many distinct LLM requests could accumulate cache files indefinitely until either (a) the instance cold-starts and `/tmp` is wiped, or (b) `/tmp` hits Vercel's ~512 MB cap and writes start failing.
+
+Failure modes when `/tmp` fills:
+- `setCachedResult` failures are caught and silently ignored (`callLlm.ts:94`, `streamLlm.ts:64`) — non-fatal.
+- `appendAnalyticsEntry` failures are caught and silently ignored (`callLlm.ts:91`, `streamLlm.ts:62`) — non-fatal.
+
+So a full `/tmp` does not break LLM calls, but it does mean analytics and cache stop working without any visible signal. From a security standpoint, this is denial-of-service-resistant (the primary path keeps working) but it is a silent reliability regression.
+
+There is no separate "leak across users" risk from leftover `/tmp` files, because each Vercel customer's `/tmp` is sandbox-isolated; when a microVM is reused for another invocation of *the same customer's* function it still belongs to the same trust domain, and when the microVM is recycled/killed the storage is destroyed.
+
+**Recommendation:** Add a soft cap on cache files (e.g., LRU eviction at N entries or M MB) and on analytics file size. Even a coarse `if (statSync(FILE_PATH).size > MAX) rotate()` is enough. Consider logging (not silently swallowing) ENOSPC errors so operators notice when `/tmp` fills.
+
+---
+
+#### No race-condition risk from `/tmp` cross-tenancy
+
+**Severity:** Informational (resolves a question raised in scope)
+**Location:** `app/lib/utils/dataDir.ts:13`
+**Move:** #4 (TOCTOU), #1 (Trust boundaries)
+**Confidence:** High
+
+The scoping prompt asked whether `/tmp` is shared across the OS user such that other tenants/processes on the same Vercel container could read what we write. The answer is no: Vercel Functions run on AWS Lambda, which uses Firecracker microVMs to isolate each customer's execution environment. `/tmp` is part of that isolated sandbox. Co-tenants on the same physical host cannot reach our `/tmp`.
+
+There is, however, a within-instance race relevant to `appendAnalyticsEntry` (`persist.ts:17-20`) regardless of Vercel. `appendFileSync` with `O_APPEND` is atomic for writes up to `PIPE_BUF` (4096 bytes on Linux), and a serialized AnalyticsEntry is well under that, so concurrent appends from parallel async handlers within one instance will not corrupt lines. This is fine. `clearAnalyticsEntries` (`persist.ts:37-40`) is not race-free vs. concurrent appends — a clear that interleaves with an append could lose the latest entry — but the impact is loss of debug data, not a security issue.
+
+**Recommendation:** None for security. Worth noting in code comments that `appendFileSync` is the correct choice here precisely because of `O_APPEND` atomicity for sub-PIPE_BUF writes — that's why the code looks safe even under concurrency.
+
+---
+
+## What Looks Good
+
+- **Cache filenames are SHA-256 hex digests, not user input.** This eliminates path-traversal risk through the most natural attack surface (hash collisions in SHA-256 are not a concern, and the digest is constrained to `[0-9a-f]{64}`).
+- **Cache contents do NOT include the user-provided `userContent` or `systemPrompt`.** Only the response `text` and `usage` metadata are written to disk. The mapping from input to response file goes through a one-way hash. This is exactly the right design for a content-addressed cache that may persist user data indirectly: an attacker who reads `/tmp/cache/*.json` learns the responses but cannot easily reconstruct what was asked (without already having candidate prompts to hash).
+- **Analytics payloads contain no PII or content.** `AnalyticsEntry` (`app/lib/types/analytics.ts:18-29`) is strictly metadata: provider, model, token counts, cost, latency, timestamp, endpoint name. Even if the analytics file were exfiltrated, no prompts or responses leak.
+- **Persistence failures are non-fatal.** Both `setCachedResult` and `appendAnalyticsEntry` are wrapped in `try/catch` at the call site (`callLlm.ts:91, 94`; `streamLlm.ts:62, 64`), so a full or read-only `/tmp` does not break the LLM flow. This is the correct error-path posture.
+- **Branching on `process.env.VERCEL` is safe.** `process.env.VERCEL` is set by the Vercel build/runtime to `1`. It is not user-controllable in any reasonable threat model (an attacker who can set process env on the deployed Function already owns the function). The fallback to `<cwd>/data` for non-Vercel is benign.
+- **No new dependencies.** The diff adds no packages, so no supply-chain review needed (cognitive move #10).
+
+---
+
+## Summary Table
+
+| # | Finding | Severity | Location | Confidence |
+|---|---------|----------|----------|------------|
+| 1 | No path traversal risk in `dataDir(...subpaths)` (informational; harden for future) | Informational | `app/lib/utils/dataDir.ts:12-15` | High |
+| 2 | Unauthenticated read/delete of analytics history (pre-existing; impact reduced by `/tmp`) | Low | `app/api/analytics/route.ts:4-12` | High |
+| 3 | Cached LLM responses readable within the same warm instance (single-tenant, but document) | Low | `app/lib/llm/cache.ts:62-69` | High |
+| 4 | No cleanup/rotation of `/tmp` cache or analytics files (silent reliability regression at cap) | Low | `app/lib/llm/cache.ts:62-69`, `app/lib/analytics/persist.ts:17-20` | High |
+| 5 | No race/cross-tenancy risk from `/tmp` (resolves a scoping question) | Informational | `app/lib/utils/dataDir.ts:13` | High |
+
+---
+
+## Overall Assessment
+
+This diff is **safe to merge from a security standpoint.** The scoping questions raised in the prompt — path traversal, cross-tenant `/tmp` reads, file permissions, leakage of user prompts — all resolve to "not exploitable" given (a) Vercel's per-customer microVM isolation of `/tmp`, (b) the absence of user input on the path-construction side of `dataDir`, and (c) the design choice to write responses indexed by hash rather than to write raw prompts.
+
+The most actionable item is the pre-existing, unauthenticated `/api/analytics` GET/DELETE endpoint (Finding 2). It is not introduced by this diff, but the diff is a reasonable place to either gate it or document deployment expectations. If the maintainer's intent is "this is a single-tenant tool deployed by individuals for their own use," the current posture is acceptable; if it could end up on a publicly-reachable Vercel preview, the endpoint should be gated.
+
+A small defense-in-depth improvement worth doing inline with this PR: reject `..` and path separators in `dataDir`'s `subpaths`, since the helper signature invites a future caller to pass user input. Cost is two lines; benefit is "a path-traversal CVE in this codebase will need to break two layers, not one."

--- a/docs/reviews/vercel-filesystem-compat/test-strategy-review.md
+++ b/docs/reviews/vercel-filesystem-compat/test-strategy-review.md
@@ -1,0 +1,140 @@
+# Test Strategy Review — `feat/vercel-filesystem-compat`
+
+Commit: b64c1cade4a69a4a5154f6cd67aa30ce7cf8841b
+
+## Scope
+
+Branch diff vs `origin/main` (3 files, +21/-2):
+
+- `app/lib/utils/dataDir.ts` — new 4-line helper that branches on `process.env.VERCEL`
+  to return `/tmp` (Vercel) or `<cwd>/data` (everywhere else), optionally joined with
+  subpaths.
+- `app/lib/analytics/persist.ts` — replaces a literal `join(process.cwd(), "data")`
+  with `dataDir()`.
+- `app/lib/llm/cache.ts` — replaces `join(process.cwd(), "data", "cache")` with
+  `dataDir("cache")`.
+
+No tests were added on this branch.
+
+## Test Conventions (project)
+
+- **Framework:** Vitest with jsdom env (`vitest.config.ts`), globals on, React Testing
+  Library available via setup file.
+- **Layout:** unit tests live next to the implementation as `<name>.test.ts(x)`. A
+  couple of areas use `__tests__/` (e.g. `app/lib/stores/__tests__/`), but the
+  surrounding directories — `app/lib/utils/`, `app/lib/llm/` — uniformly use the
+  sibling pattern. The closest existing analogue, `app/lib/llm/costs.test.ts`, uses
+  sibling-file convention with table-style `describe`/`it` blocks and pure-function
+  assertions. That is the right pattern to follow here.
+- **No env-mocking helpers** are imported anywhere in the suite today; tests that
+  need `process.env` would just save/restore in `beforeEach`/`afterEach`. Vitest's
+  `vi.stubEnv` is also available without setup.
+
+## Risk Profile
+
+`dataDir()` is a 4-line pure function, but it encodes a **deployment invariant**:
+"on Vercel we must write to `/tmp`, everywhere else we use `cwd/data`." Properties:
+
+- **Blast radius:** medium-to-high but asymmetric.
+  - If the Vercel branch is removed/inverted, production deploys silently fail at
+    runtime when analytics/cache writes hit a read-only filesystem (EROFS). The
+    failure is not visible during local dev or `npm run build`.
+  - If the non-Vercel branch breaks, every dev machine and self-hosted deploy
+    immediately fails — caught instantly.
+  - So the asymmetry is the whole reason this is interesting: the production-only
+    path has no other guard. Lint won't catch a regression, types won't catch it,
+    `npm test` won't catch it, and CI build won't exercise it.
+- **Change frequency:** low. The helper exists precisely so the env check lives in
+  one place.
+- **Surface area:** two consumers today (`persist.ts`, `cache.ts`). A third consumer
+  added without re-reading `dataDir`'s docstring is a plausible future regression
+  vector — e.g. someone uses `process.cwd()` directly for a new on-disk feature.
+- **Implementation subtlety:** `process.env.VERCEL` is truthy-checked, so any
+  non-empty string works (Vercel sets it to `"1"`). That matches Vercel's actual
+  behavior and the test should assert on string values, not booleans.
+
+## Recommended Tests
+
+### `dataDir()` env-branching unit test
+
+**Type:** unit
+**Priority:** medium-high (small cost, catches a class of silent prod regressions
+nothing else covers)
+**File:** `app/lib/utils/dataDir.test.ts` (sibling convention, matching
+`pdfPropositionParser.test.ts` / `textSelection.test.ts`)
+**What it verifies:** `dataDir()` returns `/tmp`-rooted paths iff `process.env.VERCEL`
+is set, and joins subpaths correctly under both bases.
+**Key cases:**
+- `VERCEL` unset → returns `join(process.cwd(), "data")` with no subpaths.
+- `VERCEL` unset, one subpath `"cache"` → returns `join(process.cwd(), "data", "cache")`.
+- `VERCEL` unset, multiple subpaths → joined in order under `data/`.
+- `VERCEL = "1"` → returns `"/tmp"` with no subpaths.
+- `VERCEL = "1"`, one subpath `"cache"` → returns `"/tmp/cache"`.
+- `VERCEL = ""` (empty string) → falls through to non-Vercel branch (documents the
+  truthy-check semantics; cheap to include).
+
+**Setup needed:** `vi.stubEnv("VERCEL", ...)` per case with `vi.unstubAllEnvs()` in
+`afterEach`. No fs mocking — this is a pure path-string function. Use `path.join`
+in expectations rather than hardcoded separators so the test runs on both Linux
+and Windows dev machines (though the project is Linux-first; minor point).
+
+**Cost estimate:** ~20 minutes including running the suite. ~30 lines of test code.
+
+### What this test buys you concretely
+
+The realistic regression scenarios it catches:
+
+1. Someone refactors `dataDir` and accidentally inverts the branch, or drops the
+   env check entirely (e.g. "simplify" sweep). Production breaks; local tests
+   stay green without this test. With this test, CI fails immediately.
+2. Someone changes `"VERCEL"` to a different env name (`"VERCEL_ENV"`,
+   `"NEXT_PUBLIC_VERCEL"`, etc.) without realizing the original is the deploy-set
+   sentinel. Caught.
+3. The variadic `subpaths` argument gets reworked (e.g. switched to a single
+   string) and silently breaks `cache.ts`'s `dataDir("cache")` call. Caught.
+
+It does **not** catch: actual filesystem permissions on Vercel, cold-start data
+loss, or the consumers' use of the path. Those are deployment concerns and are
+explicitly out of scope for a unit test.
+
+## What NOT to Test
+
+- **`persist.ts` / `cache.ts` integration with `dataDir()`.** The integration is a
+  one-line constant assignment; a test would either re-test `dataDir` itself or
+  pin the literal path string, which is brittle. The existing untested behavior of
+  these modules (file reads/writes/appends) was untested before this branch and
+  this PR doesn't change it. If we want coverage there it's a separate, larger
+  scope (mocking `fs`, exercising `appendAnalyticsEntry` round-trips, etc.) —
+  worth doing eventually but unrelated to the deploy-compat fix.
+- **End-to-end "does the app run on Vercel" test.** That requires a real
+  deployment and is a smoke-test concern, not a unit test. The `README` Deploy
+  to Vercel section is the right place to document this manual check.
+- **A test that asserts the exact string `"/tmp"`.** Already covered by the
+  recommended unit test; no need for a separate one.
+
+## Coverage Gaps Beyond Current Scope
+
+Noted but out of scope for this branch:
+
+- `app/lib/analytics/persist.ts` has zero tests. It uses synchronous `fs` calls and
+  parses JSONL with try/catch — there is real logic in the corrupt-line skip and
+  empty-file behavior. A small Vitest suite using `memfs` or a tmpdir would be
+  worth ~1 hour and would cover `appendAnalyticsEntry` / `readAnalyticsEntries` /
+  `clearAnalyticsEntries` round-trips. Flag for future test-strategy session.
+- `app/lib/llm/cache.ts` has zero tests. The hash function is deterministic and
+  trivially testable; the `getCachedResult` corrupt-file fallback path is the
+  interesting case. Lower priority than `persist.ts` because cache misses are
+  recoverable.
+- Neither of those gaps is created or worsened by this branch. They predate it.
+
+## Bottom Line
+
+**Recommend writing the one `dataDir.test.ts` file.** It's the cheapest possible
+guard for an asymmetric, deploy-only failure mode that no other tooling in this
+repo will catch. Skip everything else for this PR.
+
+Priority ranking:
+
+1. **`dataDir()` env-branching unit test** — recommended, ~20 min.
+2. `persist.ts` round-trip tests — defer to a separate PR; not blocking.
+3. `cache.ts` corrupt-file fallback test — defer; low priority.


### PR DESCRIPTION
## Summary

- New `app/lib/utils/dataDir.ts` resolves the writable persistence directory: `/tmp` on Vercel (where the deployed bundle is read-only and only `/tmp` is writable), `<cwd>/data` in dev and self-hosted deployments.
- `app/lib/llm/cache.ts` and `app/lib/analytics/persist.ts` now call `dataDir()` instead of hardcoding `<cwd>/data`. Without this, cache/analytics writes throw `EROFS` on Vercel and are silently swallowed.
- `dataDir.test.ts` pins both branches of the env switch — the Vercel branch is otherwise invisible to local dev/build/lint.

## Why

The codebase wrote LLM cache and analytics to `<cwd>/data/*`. On Vercel Functions the project bundle is read-only, so those writes silently failed (try/catch already wrapped them). This PR makes the writes succeed on Vercel; they don't persist across cold starts (and `/tmp` is per-Function-instance so concurrent instances see divergent contents) but at least we stop pretending we have durable storage when we don't.

## How to test

- [x] `npm test` covers `dataDir()`.
- [x] In dev: cache + analytics still land in `<repo>/data/cache/` and `<repo>/data/analytics.jsonl` as before.
- [x] On a Vercel deployment: trigger an LLM call (uses cache) and check analytics panel — neither errors. (Confirming `/tmp` writes succeed; expect no cross-cold-start persistence.)

## Risks / areas to scrutinize

- **Cache hit rate on Vercel will be low.** `/tmp` is wiped per cold start AND per-instance, so the cache degrades from "near-permanent local kv" to "best-effort warm-instance only." For low-traffic deployments where cold starts are frequent this means more LLM calls = more $$ + latency. Migration to Vercel KV / Upstash / Blob is the proper fix; cache interface is already abstracted, so it's a focused follow-up. Deferred with author note in the rubric.
- The docstring on `dataDir()` notes both the cold-start lifecycle and the per-instance caveat so future contributors don't assume durable shared state.
- `dataDir()` is currently zero-arg; if rest-args are added later, defense-in-depth filtering for `..`, `/`, `\`, `\0` in segments is recommended.

## Review artifacts

Full code review (fact-check + security + performance + api-consistency + test-strategy) in `docs/reviews/vercel-filesystem-compat/`. ✅ PASSES REVIEW with one author-noted deferred item (cache hit rate migration to KV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)