### PR TITLE
fix: use scenarios field in counterexamples evidence search

### DIFF
--- a/app/components/panels/CounterexamplesPanel.tsx
+++ b/app/components/panels/CounterexamplesPanel.tsx
@@ -38,7 +38,7 @@ export default function CounterexamplesPanel({
   const evidenceSearchContent = useMemo(() => {
     if (!counterexamples) return "";
     const parts = [counterexamples.claim];
-    for (const cx of counterexamples.counterexamples.slice(0, 3)) {
+    for (const cx of getScenarios(counterexamples)?.slice(0, 3) ?? []) {
       parts.push(cx.scenario);
     }
     return parts.filter(Boolean).join(". ");


### PR DESCRIPTION
## Summary
- PR #120 (evidence grounding) added `evidenceSearchContent` against `counterexamples.counterexamples`, but PR #130 had renamed the inner array to `scenarios`. The dangling reference broke evidence search on the counterexamples panel.
- Switch the loop to the existing `getScenarios()` legacy fallback so both new and old-shape persisted data work.

## Test plan
- [ ] Open the Counterexamples panel with a generated artifact and click "Find Evidence" — search content should include the claim plus the first three scenarios.
- [ ] Load an older workspace JSON that still uses the legacy `counterexamples` inner-array name and verify evidence search still produces content.
- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)