### PR TITLE
fix(ui): Direct Formalization scroll, custom types in node view + Generate All; OutputTypesSection abstraction

### DIFF
--- a/app/components/features/artifact-selector/OutputTypesSection.test.tsx
+++ b/app/components/features/artifact-selector/OutputTypesSection.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import OutputTypesSection from './OutputTypesSection'
+import type { CustomArtifactTypeDefinition } from '@/app/lib/types/customArtifact'
+
+// Capture what the underlying chip selector receives so we can verify the
+// abstraction forwards every prop. This is the regression guard for the
+// "one site forgot to thread custom types" failure mode.
+const chipSelectorPropsLog: Record<string, unknown>[] = []
+vi.mock('./ArtifactChipSelector', () => ({
+  default: (props: Record<string, unknown>) => {
+    chipSelectorPropsLog.push(props)
+    return <div data-testid="chip-selector" />
+  },
+}))
+
+function makeCustomType(): CustomArtifactTypeDefinition {
+  return {
+    id: 'custom-x',
+    name: 'X',
+    chipLabel: 'X',
+    description: 'desc',
+    whenToUse: 'when',
+    systemPrompt: 'prompt',
+    outputFormat: 'text',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:00:00.000Z',
+  }
+}
+
+describe('OutputTypesSection', () => {
+  beforeEach(() => {
+    chipSelectorPropsLog.length = 0
+  })
+
+  it('renders the default "Output Types" heading', () => {
+    render(<OutputTypesSection selected={[]} onChange={vi.fn()} />)
+    expect(screen.getByRole('heading', { name: 'Output Types' })).toBeInTheDocument()
+  })
+
+  it('allows overriding the heading', () => {
+    render(<OutputTypesSection selected={[]} onChange={vi.fn()} heading="Pick types" />)
+    expect(screen.getByRole('heading', { name: 'Pick types' })).toBeInTheDocument()
+  })
+
+  it('forwards selection, custom-type defs, handlers, and designer source/context to the chip selector', () => {
+    const customTypes = [makeCustomType()]
+    const onChange = vi.fn()
+    const onCreate = vi.fn()
+    const onEdit = vi.fn()
+    const onDelete = vi.fn()
+    render(
+      <OutputTypesSection
+        selected={['semiformal']}
+        onChange={onChange}
+        loading={{ semiformal: true }}
+        disabled
+        customArtifactTypes={customTypes}
+        onCreateCustomType={onCreate}
+        onEditCustomType={onEdit}
+        onDeleteCustomType={onDelete}
+        sourceText="src"
+        contextText="ctx"
+      />
+    )
+
+    const props = chipSelectorPropsLog.at(-1)
+    expect(props?.selected).toEqual(['semiformal'])
+    expect(props?.onChange).toBe(onChange)
+    expect(props?.loading).toEqual({ semiformal: true })
+    expect(props?.disabled).toBe(true)
+    // Note the property rename: outer customArtifactTypes → inner customTypes.
+    expect(props?.customTypes).toBe(customTypes)
+    expect(props?.onCreateCustomType).toBe(onCreate)
+    expect(props?.onEditCustomType).toBe(onEdit)
+    expect(props?.onDeleteCustomType).toBe(onDelete)
+    expect(props?.sourceText).toBe('src')
+    expect(props?.contextText).toBe('ctx')
+  })
+})

--- a/app/components/features/artifact-selector/OutputTypesSection.tsx
+++ b/app/components/features/artifact-selector/OutputTypesSection.tsx
@@ -1,0 +1,73 @@
+import type { ArtifactType } from "@/app/lib/types/session";
+import type { CustomArtifactTypeDefinition } from "@/app/lib/types/customArtifact";
+import ArtifactChipSelector from "./ArtifactChipSelector";
+
+/**
+ * The "Output Types" subsection: a labeled chip group that selects which
+ * artifact types (built-in and custom) a downstream action will generate.
+ *
+ * This is the single source of truth for the chip-picker UI. Anywhere a
+ * user picks artifact types — direct formalization (InputPanel), per-node
+ * formalization (NodeDetailPanel via FormalizationControls), batch
+ * "Generate All" (GraphPanel), and any future surfaces — should render
+ * this component rather than dropping in a bare ArtifactChipSelector. That
+ * way custom-type wiring, headings, and styling stay consistent and
+ * regressions like "custom types missing from view X" become impossible
+ * by construction: there's only one place to forget the props.
+ */
+type OutputTypesSectionProps = {
+  selected: ArtifactType[];
+  onChange: (types: ArtifactType[]) => void;
+  /** Per-chip loading state, used for inline spinners on running generations. */
+  loading?: Partial<Record<ArtifactType, boolean>>;
+  /** Disables all chips (e.g. while a generation is in flight). */
+  disabled?: boolean;
+  /** Custom artifact types defined in the current workspace. */
+  customArtifactTypes?: CustomArtifactTypeDefinition[];
+  onCreateCustomType?: (def: CustomArtifactTypeDefinition) => void;
+  onEditCustomType?: (def: CustomArtifactTypeDefinition) => void;
+  onDeleteCustomType?: (id: string) => void;
+  /** Source text used by the custom-type designer's test-preview panel. */
+  sourceText?: string;
+  /** Context text used by the custom-type designer's test-preview panel. */
+  contextText?: string;
+  /**
+   * Override the section heading. Defaults to "Output Types". Use sparingly —
+   * the point of this abstraction is that the heading is the same everywhere.
+   */
+  heading?: string;
+};
+
+export default function OutputTypesSection({
+  selected,
+  onChange,
+  loading,
+  disabled,
+  customArtifactTypes,
+  onCreateCustomType,
+  onEditCustomType,
+  onDeleteCustomType,
+  sourceText,
+  contextText,
+  heading = "Output Types",
+}: OutputTypesSectionProps) {
+  return (
+    <div>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
+        {heading}
+      </h3>
+      <ArtifactChipSelector
+        selected={selected}
+        onChange={onChange}
+        loading={loading}
+        disabled={disabled}
+        customTypes={customArtifactTypes}
+        onCreateCustomType={onCreateCustomType}
+        onEditCustomType={onEditCustomType}
+        onDeleteCustomType={onDeleteCustomType}
+        sourceText={sourceText}
+        contextText={contextText}
+      />
+    </div>
+  );
+}

--- a/app/components/features/formalization-controls/FormalizationControls.test.tsx
+++ b/app/components/features/formalization-controls/FormalizationControls.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import FormalizationControls from './FormalizationControls'
+
+// Stub the chip selector so this test is about the wrapper layout only.
+vi.mock('@/app/components/features/artifact-selector/ArtifactChipSelector', () => ({
+  default: () => <div data-testid="chip-selector" />,
+}))
+vi.mock('@/app/components/ui/CostTooltip', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+function baseProps() {
+  return {
+    contextText: '',
+    onContextChange: vi.fn(),
+    selectedArtifactTypes: [] as never[],
+    onArtifactTypesChange: vi.fn(),
+    onGenerate: vi.fn(),
+    loading: false,
+  }
+}
+
+describe('FormalizationControls', () => {
+  it('defaults to shrink-0 (docked) layout so callers like NodeDetailPanel keep their dock', () => {
+    const { container } = render(<FormalizationControls {...baseProps()} />)
+    const wrapper = container.firstElementChild as HTMLElement
+    expect(wrapper.className).toContain('shrink-0')
+    expect(wrapper.className).not.toContain('flex-1')
+    // The inner content area should NOT scroll in docked mode.
+    expect(wrapper.firstElementChild?.className).not.toContain('overflow-auto')
+  })
+
+  it('uses fill-height + scrollable inner area when fillHeight is set', () => {
+    // Regression: PR #95 dropped the overflow handling and the Direct
+    // Formalization section in InputPanel lost its scrollbar. fillHeight
+    // restores it while keeping the docked behavior for NodeDetailPanel.
+    const { container } = render(<FormalizationControls {...baseProps()} fillHeight />)
+    const wrapper = container.firstElementChild as HTMLElement
+    expect(wrapper.className).toContain('flex-1')
+    expect(wrapper.className).toContain('min-h-0')
+    expect(wrapper.className).toContain('overflow-hidden')
+
+    const inner = wrapper.firstElementChild as HTMLElement
+    expect(inner.className).toContain('overflow-auto')
+    expect(inner.className).toContain('flex-1')
+    expect(inner.className).toContain('min-h-0')
+  })
+})

--- a/app/components/features/formalization-controls/FormalizationControls.tsx
+++ b/app/components/features/formalization-controls/FormalizationControls.tsx
@@ -1,7 +1,7 @@
 import type { ArtifactType } from "@/app/lib/types/session";
 import type { ArtifactLoadingState } from "@/app/hooks/useArtifactGeneration";
 import type { CustomArtifactTypeDefinition } from "@/app/lib/types/customArtifact";
-import ArtifactChipSelector from "@/app/components/features/artifact-selector/ArtifactChipSelector";
+import OutputTypesSection from "@/app/components/features/artifact-selector/OutputTypesSection";
 import CostTooltip from "@/app/components/ui/CostTooltip";
 
 type FormalizationControlsProps = {
@@ -83,24 +83,18 @@ export default function FormalizationControls({
           style={{ lineHeight: 1.7, caretColor: "#000000" }}
         />
 
-        {/* Artifact type chips */}
-        <div>
-          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#6B6560]">
-            Output Types
-          </h3>
-          <ArtifactChipSelector
-            selected={selectedArtifactTypes}
-            onChange={onArtifactTypesChange}
-            loading={chipLoading}
-            disabled={loading}
-            customTypes={customArtifactTypes}
-            onCreateCustomType={onCreateCustomType}
-            onEditCustomType={onEditCustomType}
-            onDeleteCustomType={onDeleteCustomType}
-            sourceText={sourceText}
-            contextText={contextText}
-          />
-        </div>
+        <OutputTypesSection
+          selected={selectedArtifactTypes}
+          onChange={onArtifactTypesChange}
+          loading={chipLoading}
+          disabled={loading}
+          customArtifactTypes={customArtifactTypes}
+          onCreateCustomType={onCreateCustomType}
+          onEditCustomType={onEditCustomType}
+          onDeleteCustomType={onDeleteCustomType}
+          sourceText={sourceText}
+          contextText={contextText}
+        />
       </div>
 
       {/* Docked Formalise button */}

--- a/app/components/features/formalization-controls/FormalizationControls.tsx
+++ b/app/components/features/formalization-controls/FormalizationControls.tsx
@@ -23,6 +23,13 @@ type FormalizationControlsProps = {
   sourceText?: string;
   /** Source text character count, used for cost estimation tooltip. */
   sourceCharLength?: number;
+  /**
+   * When true, the component fills its parent's height and scrolls the
+   * context+chips area, keeping the Generate button docked at the bottom.
+   * When false (default), the component sizes to its content — appropriate
+   * for use as a docked bottom block (see NodeDetailPanel).
+   */
+  fillHeight?: boolean;
 };
 
 export default function FormalizationControls({
@@ -40,6 +47,7 @@ export default function FormalizationControls({
   onDeleteCustomType,
   sourceText,
   sourceCharLength,
+  fillHeight = false,
 }: FormalizationControlsProps) {
   // Derive per-chip loading booleans from loadingState
   const chipLoading: Partial<Record<ArtifactType, boolean>> = {};
@@ -53,9 +61,19 @@ export default function FormalizationControls({
       ? `Generate \u2192 ${selectedArtifactTypes.length} outputs`
       : "Generate";
 
+  // In fillHeight mode the wrapper claims remaining space and the inner
+  // section scrolls so the Generate button stays visible at the bottom.
+  // Default mode keeps the original docked behavior used by NodeDetailPanel.
+  const wrapperClass = fillHeight
+    ? "flex min-h-0 flex-1 flex-col overflow-hidden"
+    : "flex shrink-0 flex-col";
+  const scrollClass = fillHeight
+    ? "flex min-h-0 flex-1 flex-col gap-3 overflow-auto p-4"
+    : "flex flex-col gap-3 p-4";
+
   return (
-    <div className="flex shrink-0 flex-col">
-      <div className="flex flex-col gap-3 p-4">
+    <div className={wrapperClass}>
+      <div className={scrollClass}>
         <textarea
           value={contextText}
           onChange={(e) => onContextChange(e.target.value)}

--- a/app/components/panels/GraphPanel.tsx
+++ b/app/components/panels/GraphPanel.tsx
@@ -4,9 +4,10 @@ import { useState, useCallback, useMemo, useEffect } from "react";
 import dynamic from "next/dynamic";
 import type { PropositionNode, SourceDocument, GraphLayout } from "@/app/lib/types/decomposition";
 import type { ArtifactType } from "@/app/lib/types/session";
+import type { CustomArtifactTypeDefinition } from "@/app/lib/types/customArtifact";
 import type { QueueProgress } from "@/app/hooks/useAutoFormalizeQueue";
 import { useStreamingMerge } from "@/app/hooks/useStreamingMerge";
-import ArtifactChipSelector from "@/app/components/features/artifact-selector/ArtifactChipSelector";
+import OutputTypesSection from "@/app/components/features/artifact-selector/OutputTypesSection";
 import DownloadButton from "@/app/components/ui/DownloadButton";
 import CostTooltip from "@/app/components/ui/CostTooltip";
 
@@ -47,6 +48,11 @@ type GraphPanelProps = {
   onRenameNode?: (nodeId: string, label: string) => void;
   onConnectNodes?: (fromId: string, toId: string) => boolean;
   onDeleteEdges?: (edges: Array<{ source: string; target: string }>) => void;
+  /** Custom artifact type support for the "Generate All" picker. */
+  customArtifactTypes?: CustomArtifactTypeDefinition[];
+  onCreateCustomType?: (def: CustomArtifactTypeDefinition) => void;
+  onEditCustomType?: (def: CustomArtifactTypeDefinition) => void;
+  onDeleteCustomType?: (id: string) => void;
 };
 
 export default function GraphPanel({
@@ -71,6 +77,10 @@ export default function GraphPanel({
   onRenameNode,
   onConnectNodes,
   onDeleteEdges,
+  customArtifactTypes,
+  onCreateCustomType,
+  onEditCustomType,
+  onDeleteCustomType,
 }: GraphPanelProps) {
   const { displayData: displayPropositions, hasDisplayData: hasNodes } = useStreamingMerge(
     propositions.length > 0 ? propositions : null,
@@ -100,6 +110,14 @@ export default function GraphPanel({
 
   const totalInputCharLength = useMemo(
     () => sourceDocuments.reduce((sum, doc) => sum + doc.text.length, 0),
+    [sourceDocuments],
+  );
+
+  // Concatenated source text for the custom-type designer's test preview.
+  // The designer is reachable from the "Generate All" picker, so it needs
+  // representative source content; we join all sources with blank lines.
+  const combinedSourceText = useMemo(
+    () => sourceDocuments.map((d) => d.text).join("\n\n"),
     [sourceDocuments],
   );
 
@@ -261,15 +279,17 @@ export default function GraphPanel({
         </div>
       )}
 
-      {/* Artifact type picker — shown when user clicks Formalize All */}
+      {/* Artifact type picker — shown when user clicks Generate All */}
       {showArtifactPicker && (
         <div className="border-b border-[#DDD9D5] bg-[#FDFCFB] px-6 py-3">
-          <p className="mb-2 text-xs font-medium text-[#6B6560]">
-            Select output types to generate for all parts:
-          </p>
-          <ArtifactChipSelector
+          <OutputTypesSection
             selected={queueArtifactTypes}
             onChange={setQueueArtifactTypes}
+            customArtifactTypes={customArtifactTypes}
+            onCreateCustomType={onCreateCustomType}
+            onEditCustomType={onEditCustomType}
+            onDeleteCustomType={onDeleteCustomType}
+            sourceText={combinedSourceText}
           />
           <div className="mt-3 flex items-center gap-2">
             <button

--- a/app/components/panels/InputPanel.tsx
+++ b/app/components/panels/InputPanel.tsx
@@ -100,6 +100,7 @@ export default function InputPanel({
           onDeleteCustomType={onDeleteCustomType}
           sourceText={sourceText}
           sourceCharLength={sourceText.length}
+          fillHeight
         />
       </div>
     </div>

--- a/app/components/panels/NodeDetailPanel.test.tsx
+++ b/app/components/panels/NodeDetailPanel.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import NodeDetailPanel from './NodeDetailPanel'
+import type { PropositionNode } from '@/app/lib/types/decomposition'
+import type { CustomArtifactTypeDefinition } from '@/app/lib/types/customArtifact'
+
+// Capture props handed to FormalizationControls so we can assert that the
+// custom-type wiring actually reaches it. Regression guard for the bug where
+// NodeDetailPanel silently dropped customArtifactTypes & handlers.
+const formalizationControlsPropsLog: Record<string, unknown>[] = []
+vi.mock('@/app/components/features/formalization-controls/FormalizationControls', () => ({
+  default: (props: Record<string, unknown>) => {
+    formalizationControlsPropsLog.push(props)
+    return <div data-testid="formalization-controls" />
+  },
+}))
+
+function makeNode(overrides: Partial<PropositionNode> = {}): PropositionNode {
+  return {
+    id: 'n-1',
+    label: 'Node 1',
+    kind: 'assumption',
+    statement: 'The cat is on the mat.',
+    proofText: '',
+    dependsOn: [],
+    sourceId: '',
+    sourceLabel: '',
+    semiformalProof: '',
+    leanCode: '',
+    verificationStatus: 'unverified',
+    verificationErrors: '',
+    context: '',
+    selectedArtifactTypes: [],
+    artifacts: [],
+    ...overrides,
+  }
+}
+
+function makeCustomType(): CustomArtifactTypeDefinition {
+  return {
+    id: 'custom-ethics',
+    name: 'Ethical Analysis',
+    chipLabel: 'Ethics',
+    description: 'Surfaces ethical considerations',
+    whenToUse: 'Use when stakes are normative',
+    systemPrompt: 'Analyze ethically.',
+    outputFormat: 'text',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:00:00.000Z',
+  }
+}
+
+describe('NodeDetailPanel', () => {
+  beforeEach(() => {
+    formalizationControlsPropsLog.length = 0
+  })
+
+  const defaultProps = {
+    node: makeNode(),
+    dependencies: [],
+    onFormalise: vi.fn(),
+    onGenerateLean: vi.fn(),
+    loading: false,
+    globalContextText: '',
+    onNodeContextChange: vi.fn(),
+    onNodeArtifactTypesChange: vi.fn(),
+  }
+
+  it('renders the node label and FormalizationControls', () => {
+    render(<NodeDetailPanel {...defaultProps} />)
+    expect(screen.getByText('Node 1')).toBeInTheDocument()
+    expect(screen.getByTestId('formalization-controls')).toBeInTheDocument()
+  })
+
+  it('threads custom artifact types and handlers to FormalizationControls', () => {
+    const customTypes = [makeCustomType()]
+    const onCreate = vi.fn()
+    const onEdit = vi.fn()
+    const onDelete = vi.fn()
+
+    render(
+      <NodeDetailPanel
+        {...defaultProps}
+        customArtifactTypes={customTypes}
+        onCreateCustomType={onCreate}
+        onEditCustomType={onEdit}
+        onDeleteCustomType={onDelete}
+      />
+    )
+
+    const props = formalizationControlsPropsLog.at(-1)
+    expect(props?.customArtifactTypes).toBe(customTypes)
+    expect(props?.onCreateCustomType).toBe(onCreate)
+    expect(props?.onEditCustomType).toBe(onEdit)
+    expect(props?.onDeleteCustomType).toBe(onDelete)
+  })
+
+  it('passes the node statement as the test-preview source and includes proofText in cost length', () => {
+    const node = makeNode({ statement: 'A claim.', proofText: 'Because reasons.' })
+    render(<NodeDetailPanel {...defaultProps} node={node} />)
+
+    const props = formalizationControlsPropsLog.at(-1)
+    expect(props?.sourceText).toBe('A claim.')
+    expect(props?.sourceCharLength).toBe('A claim.'.length + 'Because reasons.'.length)
+  })
+})

--- a/app/components/panels/NodeDetailPanel.tsx
+++ b/app/components/panels/NodeDetailPanel.tsx
@@ -3,6 +3,7 @@
 import type { PropositionNode, NodeVerificationStatus } from "@/app/lib/types/decomposition";
 import type { ArtifactType } from "@/app/lib/types/session";
 import type { ArtifactLoadingState } from "@/app/hooks/useArtifactGeneration";
+import type { CustomArtifactTypeDefinition } from "@/app/lib/types/customArtifact";
 import FormalizationControls from "@/app/components/features/formalization-controls/FormalizationControls";
 import CollapsibleSection from "@/app/components/ui/CollapsibleSection";
 
@@ -18,6 +19,11 @@ type NodeDetailPanelProps = {
   onNodeContextChange: (text: string) => void;
   onNodeArtifactTypesChange: (types: ArtifactType[]) => void;
   loadingState?: ArtifactLoadingState;
+  /** Custom artifact type support — threaded through to the chip selector */
+  customArtifactTypes?: CustomArtifactTypeDefinition[];
+  onCreateCustomType?: (def: CustomArtifactTypeDefinition) => void;
+  onEditCustomType?: (def: CustomArtifactTypeDefinition) => void;
+  onDeleteCustomType?: (id: string) => void;
 };
 
 const STATUS_LABELS: Record<NodeVerificationStatus, { text: string; color: string }> = {
@@ -30,6 +36,7 @@ const STATUS_LABELS: Record<NodeVerificationStatus, { text: string; color: strin
 export default function NodeDetailPanel({
   node, dependencies, onFormalise, onGenerateLean, loading,
   globalContextText, onNodeContextChange, onNodeArtifactTypesChange, loadingState = {},
+  customArtifactTypes, onCreateCustomType, onEditCustomType, onDeleteCustomType,
 }: NodeDetailPanelProps) {
   const status = STATUS_LABELS[node.verificationStatus];
 
@@ -155,6 +162,14 @@ export default function NodeDetailPanel({
             loading={loading}
             loadingState={loadingState}
             contextPlaceholder={globalContextText || "e.g., Analyze this from a decision-making perspective, considering strategic interactions between actors..."}
+            customArtifactTypes={customArtifactTypes}
+            onCreateCustomType={onCreateCustomType}
+            onEditCustomType={onEditCustomType}
+            onDeleteCustomType={onDeleteCustomType}
+            // The node's statement is what the formalization actually runs on, so
+            // it doubles as the designer test preview source and the cost input.
+            sourceText={node.statement}
+            sourceCharLength={node.statement.length + (node.proofText?.length ?? 0)}
           />
         </div>
       </div>

--- a/app/hooks/useAutoFormalizeQueue.ts
+++ b/app/hooks/useAutoFormalizeQueue.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import type { PropositionNode } from "@/app/lib/types/decomposition";
 import type { ArtifactType } from "@/app/lib/types/session";
+import type { CustomArtifactTypeDefinition } from "@/app/lib/types/customArtifact";
 import { topologicalSort } from "@/app/lib/utils/topologicalSort";
 import { formalizeNode, type CancelSignal } from "@/app/lib/formalization/formalizeNode";
 
@@ -30,6 +31,7 @@ export function useAutoFormalizeQueue(
   nodes: PropositionNode[],
   updateNode: (id: string, updates: Partial<PropositionNode>) => void,
   contextText?: string,
+  customTypeDefs?: CustomArtifactTypeDefinition[],
 ) {
   const [progress, setProgress] = useState<QueueProgress>(INITIAL_PROGRESS);
 
@@ -43,6 +45,10 @@ export function useAutoFormalizeQueue(
   // next node, not the one currently being formalized.
   const contextTextRef = useRef(contextText);
   useEffect(() => { contextTextRef.current = contextText; }, [contextText]);
+  // Same ref pattern for custom-type definitions so updates mid-run apply
+  // to the next node rather than recreating start() on every workspace edit.
+  const customTypeDefsRef = useRef(customTypeDefs);
+  useEffect(() => { customTypeDefsRef.current = customTypeDefs; }, [customTypeDefs]);
 
   const start = useCallback(async (artifactTypes?: ArtifactType[]) => {
     if (runningRef.current) return;
@@ -125,7 +131,15 @@ export function useAutoFormalizeQueue(
 
       setProgress((p) => ({ ...p, currentNodeId: nodeId }));
 
-      const result = await formalizeNode(node, nodes, updateNode, cancelSignalRef.current, artifactTypes, contextTextRef.current);
+      const result = await formalizeNode(
+        node,
+        nodes,
+        updateNode,
+        cancelSignalRef.current,
+        artifactTypes,
+        contextTextRef.current,
+        customTypeDefsRef.current,
+      );
 
       if (cancelSignalRef.current.cancelled) break;
 

--- a/app/lib/formalization/formalizeNode.test.ts
+++ b/app/lib/formalization/formalizeNode.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { formalizeNode } from './formalizeNode'
+import type { PropositionNode } from '@/app/lib/types/decomposition'
+import type { CustomArtifactTypeDefinition } from '@/app/lib/types/customArtifact'
+
+// Mock the API layer. We're testing dispatch logic, not network behavior.
+const fetchApi = vi.fn()
+vi.mock('@/app/lib/formalization/api', () => ({
+  fetchApi: (...args: unknown[]) => fetchApi(...args),
+  generateSemiformal: vi.fn(),
+}))
+vi.mock('@/app/lib/formalization/leanRetryLoop', () => ({
+  leanRetryLoop: vi.fn(),
+}))
+
+function makeNode(overrides: Partial<PropositionNode> = {}): PropositionNode {
+  return {
+    id: 'n-1',
+    label: 'Node',
+    kind: 'assumption',
+    statement: 'The thing is true.',
+    proofText: '',
+    dependsOn: [],
+    sourceId: '',
+    sourceLabel: '',
+    semiformalProof: '',
+    leanCode: '',
+    verificationStatus: 'unverified',
+    verificationErrors: '',
+    context: '',
+    selectedArtifactTypes: [],
+    artifacts: [],
+    ...overrides,
+  }
+}
+
+function makeCustomDef(overrides: Partial<CustomArtifactTypeDefinition> = {}): CustomArtifactTypeDefinition {
+  return {
+    id: 'custom-ethics',
+    name: 'Ethical Analysis',
+    chipLabel: 'Ethics',
+    description: 'desc',
+    whenToUse: 'when',
+    systemPrompt: 'Analyze ethically.',
+    outputFormat: 'text',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('formalizeNode — custom type dispatch (Generate All path)', () => {
+  beforeEach(() => {
+    fetchApi.mockReset()
+  })
+
+  it('dispatches a custom type to /api/formalization/custom with the system prompt and writes the result onto the node', async () => {
+    fetchApi.mockResolvedValueOnce({ result: 'Ethical assessment output.' })
+    const def = makeCustomDef()
+    const node = makeNode()
+    const updates: Array<Partial<PropositionNode>> = []
+    const updateNode = (_id: string, patch: Partial<PropositionNode>) => { updates.push(patch) }
+
+    const status = await formalizeNode(
+      node, [node], updateNode, undefined,
+      [def.id], 'global ctx', [def],
+    )
+
+    expect(status).toBe('verified')
+    // Exactly one call — to the custom route — with the system prompt in body.
+    expect(fetchApi).toHaveBeenCalledTimes(1)
+    const [route, body] = fetchApi.mock.calls[0] as [string, Record<string, unknown>]
+    expect(route).toBe('/api/formalization/custom')
+    expect(body.customSystemPrompt).toBe('Analyze ethically.')
+    expect(body.customOutputFormat).toBe('text')
+    expect(body.sourceText).toContain('The thing is true.')
+
+    // The generated artifact ends up on the node.
+    const artifactPatch = updates.find((p) => Array.isArray(p.artifacts))
+    expect(artifactPatch?.artifacts).toEqual([
+      expect.objectContaining({ type: def.id, content: 'Ethical assessment output.' }),
+    ])
+  })
+
+  it('silently skips custom types whose definitions are not in the workspace (defensive against stale selections)', async () => {
+    const node = makeNode()
+    const updates: Array<Partial<PropositionNode>> = []
+    const updateNode = (_id: string, patch: Partial<PropositionNode>) => { updates.push(patch) }
+
+    const status = await formalizeNode(
+      node, [node], updateNode, undefined,
+      ['custom-missing'], '', [],
+    )
+
+    expect(status).toBe('verified')
+    expect(fetchApi).not.toHaveBeenCalled()
+    expect(updates.some((p) => Array.isArray(p.artifacts))).toBe(false)
+  })
+})

--- a/app/lib/formalization/formalizeNode.ts
+++ b/app/lib/formalization/formalizeNode.ts
@@ -1,6 +1,6 @@
 import type { PropositionNode, NodeArtifact } from "@/app/lib/types/decomposition";
 import type { ArtifactType, BuiltinArtifactType } from "@/app/lib/types/session";
-import { isCustomType } from "@/app/lib/types/customArtifact";
+import { isCustomType, type CustomArtifactTypeDefinition } from "@/app/lib/types/customArtifact";
 import type { ArtifactGenerationRequest } from "@/app/lib/types/artifacts";
 import { gatherDependencyContext } from "@/app/lib/utils/leanContext";
 import { generateSemiformal, fetchApi } from "@/app/lib/formalization/api";
@@ -24,6 +24,13 @@ export async function formalizeNode(
   signal?: CancelSignal,
   artifactTypes?: ArtifactType[],
   contextText?: string,
+  /**
+   * Definitions for custom artifact types selected via "Generate All". The
+   * queue needs these to dispatch custom types to /api/formalization/custom
+   * (the per-node path in useArtifactGeneration uses the same route).
+   * Omit or pass [] to skip custom types — matches the legacy behavior.
+   */
+  customTypeDefs?: CustomArtifactTypeDefinition[],
 ): Promise<"verified" | "failed"> {
   // If no artifact types specified, default to legacy deductive pipeline
   const types = artifactTypes && artifactTypes.length > 0 ? artifactTypes : ["semiformal" as ArtifactType];
@@ -65,7 +72,7 @@ export async function formalizeNode(
     // Run non-deductive artifact generation in parallel
     if (nonDeductiveTypes.length > 0) {
       const request: ArtifactGenerationRequest = { sourceText: nodeText, context, nodeId: node.id, nodeLabel: node.label };
-      const artifactResults = await generateNonDeductiveArtifacts(nonDeductiveTypes, request, signal);
+      const artifactResults = await generateNonDeductiveArtifacts(nonDeductiveTypes, request, signal, customTypeDefs);
 
       if (signal?.cancelled) {
         updateNode(node.id, { verificationStatus: "unverified", verificationErrors: "" });
@@ -109,11 +116,37 @@ async function generateNonDeductiveArtifacts(
   types: ArtifactType[],
   request: ArtifactGenerationRequest,
   signal?: CancelSignal,
+  customTypeDefs?: CustomArtifactTypeDefinition[],
 ): Promise<Array<{ type: ArtifactType; content: unknown }>> {
+  // Index custom defs by id for O(1) lookup inside the per-type promise.
+  // Mirrors useArtifactGeneration so single-node and batch paths agree.
+  const customDefsById = new Map((customTypeDefs ?? []).map((d) => [d.id, d]));
+
   const promises = types.map(async (type): Promise<{ type: ArtifactType; content: unknown } | null> => {
     if (signal?.cancelled) return null;
-    // formalizeNode only handles built-in types (custom types go through useArtifactGeneration)
-    if (isCustomType(type)) return null;
+
+    // Custom artifact types: dispatch to /api/formalization/custom with the
+    // user's system prompt. Without a matching definition we skip silently —
+    // the type was selected but its definition isn't in the workspace.
+    if (isCustomType(type)) {
+      const def = customDefsById.get(type);
+      if (!def) return null;
+      try {
+        const data = await fetchApi<Record<string, unknown>>(
+          "/api/formalization/custom",
+          {
+            ...request,
+            customSystemPrompt: def.systemPrompt,
+            customOutputFormat: def.outputFormat,
+          },
+        );
+        return { type, content: data.result ?? null };
+      } catch (err) {
+        console.error(`[formalizeNode:${type}]`, err);
+        return null;
+      }
+    }
+
     const builtinType = type as BuiltinArtifactType;
     const route = ARTIFACT_ROUTE[builtinType];
     if (!route) return null;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -330,7 +330,7 @@ export default function Home() {
   );
 
   // --- Auto-formalize queue ---
-  const { progress: queueProgress, start: startQueue, pause: pauseQueue, resume: resumeQueue, cancel: cancelQueue, reset: resetQueue } = useAutoFormalizeQueue(decomp.nodes, updateNode, contextText);
+  const { progress: queueProgress, start: startQueue, pause: pauseQueue, resume: resumeQueue, cancel: cancelQueue, reset: resetQueue } = useAutoFormalizeQueue(decomp.nodes, updateNode, contextText, customArtifactTypes);
   const queueRunning = queueProgress.status === "running" || queueProgress.status === "paused";
 
   // Restore decomposition from persisted store once on mount (one-time read, no subscription)
@@ -920,6 +920,10 @@ export default function Home() {
             onRenameNode={renameGraphNode}
             onConnectNodes={addGraphEdge}
             onDeleteEdges={handleDeleteEdges}
+            customArtifactTypes={customArtifactTypes}
+            onCreateCustomType={addCustomArtifactType}
+            onEditCustomType={(def) => updateCustomArtifactType(def.id, def)}
+            onDeleteCustomType={handleDeleteCustomType}
           />
         );
       case "node-detail":

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -934,6 +934,10 @@ export default function Home() {
             onNodeContextChange={(text) => updateNode(selectedNode.id, { context: text })}
             onNodeArtifactTypesChange={(types) => updateNode(selectedNode.id, { selectedArtifactTypes: types })}
             loadingState={artifactLoadingState}
+            customArtifactTypes={customArtifactTypes}
+            onCreateCustomType={addCustomArtifactType}
+            onEditCustomType={(def) => updateCustomArtifactType(def.id, def)}
+            onDeleteCustomType={handleDeleteCustomType}
           />
         ) : undefined;
       case "causal-graph":


### PR DESCRIPTION
Two UI bugs against `integration/5.21`, plus the abstraction that makes the same class of bug structurally harder to reintroduce.

## Bugs fixed

1. **Direct Formalization panel lost its scrollbar.** PR #95 changed `FormalizationControls` from `flex-1 min-h-0 overflow-hidden` + inner `overflow-auto` to a bare `shrink-0 flex-col` to fix a docking issue in `NodeDetailPanel`. That removed the overflow handling `InputPanel`'s bottom section depended on — the textarea + chips + Generate button got clipped instead of scrolling.
2. **Custom artifact types didn't appear in the per-node formalization view.** `NodeDetailPanel` never accepted `customArtifactTypes` / `onCreate` / `onEdit` / `onDeleteCustomType` / `sourceText` props, so they were silently dropped between `page.tsx` and `FormalizationControls` → `ArtifactChipSelector`.
3. **Custom types also weren't wired into "Generate All" on the decomposition page** — and even if the UI had passed them, the queue path (`formalizeNode`) silently skipped custom types via an early `return null`.

## What changed

**Abstraction** (new): `OutputTypesSection` (`app/components/features/artifact-selector/OutputTypesSection.tsx`) is the single source of truth for the Output Types chip picker. It wraps `ArtifactChipSelector` with the heading + every custom-type prop. After this PR, the only non-test consumer of `ArtifactChipSelector` is `OutputTypesSection` itself (verified via grep).

**Callers refactored to use it:**
- `FormalizationControls` — used by `InputPanel` (Direct Formalization) and `NodeDetailPanel` (per-node).
- `GraphPanel` — "Generate All" picker. New: accepts `customArtifactTypes` + the three handlers; passes the concatenated source-document text as the designer test-preview source.

**Scroll fix**: `FormalizationControls` gains an opt-in `fillHeight` prop. Default behavior keeps the PR #95 `shrink-0` dock (which `NodeDetailPanel` still needs). `InputPanel` passes `fillHeight` to restore the scrollable wrapper for Direct Formalization.

**Queue backend wired**: `formalizeNode` now accepts `customTypeDefs` and dispatches matching custom types to `/api/formalization/custom` with the user's system prompt — same route the per-node `useArtifactGeneration` path uses. `useAutoFormalizeQueue` accepts `customTypeDefs` via the same ref pattern as `contextText` (mid-run workspace edits apply to the next node, not the in-flight one). `page.tsx` threads `customArtifactTypes` into both the queue hook and `GraphPanel`.

## How to test

1. **Direct Formalization scroll** — open the Source panel, add 3+ custom artifact types so the chip area is tall, shrink the window vertically. Expected: the context + chips area scrolls; the Generate button stays docked at the bottom.
2. **Custom types in node view** — decompose a source into nodes, click into any node. Expected: any custom artifact types defined in the workspace appear in the per-node Output Types picker; the designer is reachable and shows the node statement as the preview source.
3. **Generate All with a custom type** — on the decomposition page, click "Generate All", select a custom type alongside the built-in ones, click Start. Expected: the queue dispatches the custom type to `/api/formalization/custom` per node and writes the result onto the node's `artifacts[]`. Previously: silently skipped.

## Tests

- `FormalizationControls.test.tsx` (new) — asserts the default vs `fillHeight` wrapper class layout. Regression guard for the scroll fix.
- `NodeDetailPanel.test.tsx` (new) — asserts the custom-type bundle reaches `FormalizationControls`; asserts the node statement / proofText feed the designer + cost tooltip.
- `OutputTypesSection.test.tsx` (new) — full prop-forwarding regression including the outer `customArtifactTypes` → inner `customTypes` rename.
- `formalizeNode.test.ts` (new) — queue-path custom-type dispatch hits `/api/formalization/custom` with the system prompt and writes the result onto the node; missing definitions are silently skipped.

Full suite: **390 tests / 42 files** pass. Lint clean. Build succeeds.

## Areas to scrutinize

- The `OutputTypesSection` rename (`customArtifactTypes` outer → `customTypes` inner forwarding) — easy to miss in code review; covered by `OutputTypesSection.test.tsx` but worth a second pair of eyes.
- `formalizeNode` now silently *skips* custom types whose definitions aren't in the workspace, rather than returning a noisy error. Rationale: defensive against stale selections after a session switch deletes a custom type. Test covers this; if you'd prefer an explicit error surface, say so and I'll add a console warning.
- `GraphPanel` now memos `combinedSourceText` (joins all source documents) for the designer preview. Cost is one `Array.map(...).join("\n\n")` per render of a workspace with N sources; bounded by `sourceDocuments` (small N in practice).
- The OPFS / FSA / git architectural redirect captured in `docs/decisions/009-artifact-corpus-architecture.md` (separate branch) is the durable fix for the session-snapshot bug *class*. This PR closes the immediate UI symptoms but is explicitly **not** a substitute for that work.

## Out of scope

- Architectural changes to persistence — see `docs/decision-009-artifact-corpus-architecture` branch.
- Conflict resolution when two devices regenerate the same artifact.
- UI for managing workspace-level custom type history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)